### PR TITLE
Fix unsafe conversion from double to int

### DIFF
--- a/src/pspc/solvers/Block.tpp
+++ b/src/pspc/solvers/Block.tpp
@@ -71,7 +71,7 @@ namespace Pspc {
          tempNs = 1;
       } 
       ds_ = (length()/double(tempNs * 2.0));
-      ns_ = (length()/ds_)  + 1;
+      ns_ = std::round((length()/ds_)  + 1);
 
       // Compute Fourier space kMeshDimensions_ 
       for (int i = 0; i < D; ++i) {


### PR DESCRIPTION
Our postdoc Sojung found that in specific rare cases:
e.g. (length()/ds_)  + 1 = 477 is stored as 476.99999 which when converted to int results in 476
that results in the incorrect quadrature integration of volume fraction that requires odd numbers of indices