### PR TITLE
Double weighted monomer concentration in blend system

### DIFF
--- a/src/pspc/solvers/Mixture.tpp
+++ b/src/pspc/solvers/Mixture.tpp
@@ -106,9 +106,7 @@ namespace Pspc
       }
 
       // Accumulate monomer concentration fields
-      double phi;
       for (i = 0; i < nPolymer(); ++i) {
-         phi = polymer(i).phi();
          for (j = 0; j < polymer(i).nBlock(); ++j) {
             int monomerId = polymer(i).block(j).monomerId();
             UTIL_CHECK(monomerId >= 0);
@@ -116,7 +114,7 @@ namespace Pspc
             CField& monomerField = cFields[monomerId];
             CField& blockField = polymer(i).block(j).cField();
             for (k = 0; k < nx; ++k) {
-               monomerField[k] += phi * blockField[k];
+               monomerField[k] += blockField[k];
             }
          }
       }


### PR DESCRIPTION
When computing total monomer concentration (monomerField) for each monomer type, volume fractions (phi) of each molecule species are used as the weighting factors. In line 457 of PolymerTmpl.h of Pscf::PolymerTmpl< Block > class template, computeConcentration function is called with an input which is a prefactor of integral for calculating concentration for each block. The prefactor already contains the volume fractions (phi) of each molecule species. This makes the concentrations double-weighted, resulting in that the monomer volume fraction fields in the output file are not summed up to 1.