### PR TITLE
Fixed bug that gives NaN for free energy when component has phi=0

### DIFF
--- a/src/fd1d/System.cpp
+++ b/src/fd1d/System.cpp
@@ -388,7 +388,9 @@ namespace Fd1d
             mu = polymerPtr->mu();
             // Recall: mu = ln(phi/q)
             length = polymerPtr->length();
-            fHelmholtz_ += phi*( mu - 1.0 )/length;
+            if (phi > 1E-08) {
+               fHelmholtz_ += phi*( mu - 1.0 )/length;
+            }
          }
       }
 
@@ -402,7 +404,9 @@ namespace Fd1d
             mu = solventPtr->mu();
             // Recall: mu = ln(phi/q)
             size = solventPtr->size();
-            fHelmholtz_ += phi*( mu - 1.0 )/size;
+            if (phi > 1E-08) {
+               fHelmholtz_ += phi*( mu - 1.0 )/size;
+            }
          }
       }
 
@@ -437,7 +441,9 @@ namespace Fd1d
             phi = polymerPtr->phi();
             mu = polymerPtr->mu();
             length = polymerPtr->length();
-            pressure_ += phi*mu/length;
+            if (phi > 1E-08) {
+               pressure_ += phi*mu/length;
+            }
          }
       }
       if (ns > 0) {
@@ -448,7 +454,9 @@ namespace Fd1d
             phi = solventPtr->phi();
             mu = solventPtr->mu();
             size = solventPtr->size();
-            pressure_ += phi*mu/size;
+            if (phi > 1E-08) {
+               pressure_ += phi*mu/size;
+            }
          }
       }
 

--- a/src/pspc/System.tpp
+++ b/src/pspc/System.tpp
@@ -483,7 +483,9 @@ namespace Pspc
             mu = polymerPtr->mu();
             length = polymerPtr->length();
             // Recall: mu = ln(phi/q)
-            fHelmholtz_ += phi*( mu - 1.0 )/length;
+            if (phi > 1E-08) {
+               fHelmholtz_ += phi*( mu - 1.0 )/length;
+            }
          }
       }
 
@@ -496,7 +498,9 @@ namespace Pspc
             phi = solventPtr->phi();
             mu = solventPtr->mu();
             size = solventPtr->size();
-            fHelmholtz_ += phi*( mu - 1.0 )/size;
+            if (phi > 1E-08) {
+               fHelmholtz_ += phi*( mu - 1.0 )/size;
+            }
          }
       }
 
@@ -536,7 +540,9 @@ namespace Pspc
             phi = polymerPtr->phi();
             mu = polymerPtr->mu();
             length = polymerPtr->length();
-            pressure_ += mu * phi /length;
+            if (phi > 1E-08) {
+               pressure_ += mu * phi /length;
+            }
          }
       }
 
@@ -549,7 +555,9 @@ namespace Pspc
             phi = solventPtr->phi();
             mu = solventPtr->mu();
             size = solventPtr->size();
-            pressure_ += mu * phi /size;
+            if (phi > 1E-08) {
+               pressure_ += mu * phi /size;
+            }
          }
       }
 

--- a/src/pspg/System.tpp
+++ b/src/pspg/System.tpp
@@ -582,7 +582,9 @@ namespace Pspg
             mu = polymerPtr->mu();
             // Recall: mu = ln(phi/q)
             length = polymerPtr->length();
-            fHelmholtz_ += phi*( mu - 1.0 )/length;
+            if (phi > 1E-08) {
+               fHelmholtz_ += phi*( mu - 1.0 )/length;
+            }
          }
       }
 
@@ -595,7 +597,9 @@ namespace Pspg
             phi = solventPtr->phi();
             mu = solventPtr->mu();
             size = solventPtr->size();
-            fHelmholtz_ += phi*( mu - 1.0 )/size;
+            if (phi > 1E-08) {
+               fHelmholtz_ += phi*( mu - 1.0 )/size;
+            }
          }
       }
 
@@ -637,7 +641,9 @@ namespace Pspg
             phi = polymerPtr->phi();
             mu = polymerPtr->mu();
             length = polymerPtr->length();
-            pressure_ += mu * phi /length;
+            if (phi > 1E-08) {
+               pressure_ += mu * phi /length;
+            }
          }
       }
 
@@ -650,7 +656,9 @@ namespace Pspg
             phi = solventPtr->phi();
             mu = solventPtr->mu();
             size = solventPtr->size();
-            pressure_ += mu * phi /size;
+            if (phi > 1E-08) {
+               pressure_ += mu * phi /size;
+            }
          }
       }
 


### PR DESCRIPTION
When a solvent or polymer is included in the param file but has phi=0, the calculated free energy and pressure of the system are erroneously NaN because the software is calculating 0*(-inf) as the contribution of the nonexistent species to the free energy. This pull request will fix this bug for fd1d, pspc, and pspg by only calculating the free energy contributions of species for which phi>1E-08.