### PR TITLE
New command WRITE_C_BLOCK_RGRID added

### DIFF
--- a/docs/manual/user/command_fd.dox
+++ b/docs/manual/user/command_fd.dox
@@ -50,11 +50,6 @@ The following table shows a list of available commands for pscf_fd:
          they appear in the param file </td>
   </tr>
   <tr> 
-    <td> WRITE_BLOCK_C </td>
-    <td> filename [string] </td>
-    <td> Write monomer volume fractions for each block to file filename  </td>
-  </tr>
-  <tr> 
     <td> COMPARE_HOMOGENEOUS </td>
     <td> mode [int] </td>
     <td> Compare solution to homogeneous solution(s)  </td>

--- a/docs/manual/user/command_fd.dox
+++ b/docs/manual/user/command_fd.dox
@@ -44,6 +44,14 @@ The following table shows a list of available commands for pscf_fd:
   <tr> 
     <td> WRITE_BLOCK_C </td>
     <td> filename [string] </td>
+    <td> Write individual block/solvent volume fraction (c) fields to
+         file filename. The block c fields are given in the order they
+         appear in the param file, followed by the solvents in the order
+         they appear in the param file </td>
+  </tr>
+  <tr> 
+    <td> WRITE_BLOCK_C </td>
+    <td> filename [string] </td>
     <td> Write monomer volume fractions for each block to file filename  </td>
   </tr>
   <tr> 

--- a/docs/manual/user/command_fd.dox
+++ b/docs/manual/user/command_fd.dox
@@ -44,10 +44,10 @@ The following table shows a list of available commands for pscf_fd:
   <tr> 
     <td> WRITE_BLOCK_C </td>
     <td> filename [string] </td>
-    <td> Write individual block/solvent volume fraction (c) fields to
-         file filename. The block c fields are given in the order they
-         appear in the param file, followed by the solvents in the order
-         they appear in the param file </td>
+    <td> Write individual block/solvent volume fraction (c) fields to file
+         filename. The block c fields are given in the order that the blocks
+         appear in the param file, followed by the solvent fields in the
+         order that the solvents appear in the param file </td>
   </tr>
   <tr> 
     <td> COMPARE_HOMOGENEOUS </td>

--- a/docs/manual/user/command_pc.dox
+++ b/docs/manual/user/command_pc.dox
@@ -99,8 +99,9 @@ programs:
     <td> filename [string] </td>
     <td> Write individual block/solvent volume fraction fields (c fields) to
          file filename, in r-grid format. The block c fields are given in
-         the order they appear in the param file, followed by the solvents
-         in the order they appear in the param file </td>
+         the order that the blocks appear in the param file, followed by the
+         solvent fields in the order that the solvents appear in the param 
+         file </td>
   </tr>
   <tr> 
     <td> RGRID_TO_BASIS </td>

--- a/docs/manual/user/command_pc.dox
+++ b/docs/manual/user/command_pc.dox
@@ -95,6 +95,14 @@ programs:
          in r-grid format  </td>
   </tr>
   <tr> 
+    <td> WRITE_C_BLOCK_RGRID </td>
+    <td> filename [string] </td>
+    <td> Write individual block/solvent volume fraction fields (c fields) to
+         file filename, in r-grid format. The block c fields are given in
+         the order they appear in the param file, followed by the solvents
+         in the order they appear in the param file </td>
+  </tr>
+  <tr> 
     <td> RGRID_TO_BASIS </td>
     <td> inFile [string], outFile[string </td>
     <td> Read fields from file inFile in real-space grid (r-grid) format, 

--- a/docs/manual/user/command_pg.dox
+++ b/docs/manual/user/command_pg.dox
@@ -85,8 +85,9 @@ pscf_pg2d, and pscf_pg3d).
     <td> filename [string] </td>
     <td> Write individual block/solvent volume fraction fields (c fields) to
          file filename, in r-grid format. The block c fields are given in
-         the order they appear in the param file, followed by the solvents
-         in the order they appear in the param file </td>
+         the order that the blocks appear in the param file, followed by the
+         solvent fields in the order that the solvents appear in the param 
+         file </td>
   </tr>
   <tr> 
     <td> RGRID_TO_BASIS </td>

--- a/docs/manual/user/command_pg.dox
+++ b/docs/manual/user/command_pg.dox
@@ -81,6 +81,14 @@ pscf_pg2d, and pscf_pg3d).
          in r-grid format  </td>
   </tr>
   <tr> 
+    <td> WRITE_C_BLOCK_RGRID </td>
+    <td> filename [string] </td>
+    <td> Write individual block/solvent volume fraction fields (c fields) to
+         file filename, in r-grid format. The block c fields are given in
+         the order they appear in the param file, followed by the solvents
+         in the order they appear in the param file </td>
+  </tr>
+  <tr> 
     <td> RGRID_TO_BASIS </td>
     <td> inFile [string], outFile[string </td>
     <td> Read fields from file inFile in real-space grid (r-grid) format, 

--- a/src/fd1d/System.cpp
+++ b/src/fd1d/System.cpp
@@ -124,7 +124,7 @@ namespace Fd1d
             iArg  = optarg;
             break;
          case 'o': // output prefix
-            iFlag = true;
+            oFlag = true;
             oArg  = optarg;
             break;
          case '?':

--- a/src/fd1d/misc/FieldIo.cpp
+++ b/src/fd1d/misc/FieldIo.cpp
@@ -116,7 +116,14 @@ namespace Fd1d
       int nx = domain().nx();          // number grid points
       int np = mixture().nPolymer();   // number of polymer species
       int nb;                          // number of blocks per polymer
-      int i, j, k;
+      int nb_tot = mixture().nBlock(); // number of blocks in whole system
+      int ns = mixture().nSolvent();   // number of solvents
+
+      out << "nx          "  <<  nx              << std::endl;
+      out << "n_block     "  <<  nb_tot          << std::endl;
+      out << "n_solvent   "  <<  ns              << std::endl;
+
+      int i, j, k, l;
       double c;
       for (i = 0; i < nx; ++i) {
          out << Int(i, 5);
@@ -126,6 +133,10 @@ namespace Fd1d
                c = mixture().polymer(j).block(k).cField()[i];
                out << " " << Dbl(c, 15, 8);
             }
+         }
+         for (l = 0; l < ns; ++l) {
+               c = mixture().solvent(l).cField()[i];
+               out << " " << Dbl(c, 15, 8);
          }
          out << std::endl;
       }

--- a/src/pscf/solvers/BlockTmpl.h
+++ b/src/pscf/solvers/BlockTmpl.h
@@ -140,6 +140,11 @@ namespace Pscf
       * Get the associated monomer concentration field.
       */
       typename TP::CField& cField();
+
+      /**
+      * Get the associated const monomer concentration field.
+      */
+      typename TP::CField const & cField() const;
    
       /**
       * Get monomer statistical segment length.
@@ -183,6 +188,14 @@ namespace Pscf
    template <class TP>
    inline
    typename TP::CField& BlockTmpl<TP>::cField()
+   {  return cField_; }
+
+   /*
+   * Get the const monomer concentration field.
+   */
+   template <class TP>
+   inline
+   typename TP::CField const & BlockTmpl<TP>::cField() const
    {  return cField_; }
 
    /*

--- a/src/pscf/solvers/MixtureTmpl.h
+++ b/src/pscf/solvers/MixtureTmpl.h
@@ -110,16 +110,15 @@ namespace Pscf
       */
       int nPolymer() const;
 
+      /** 
+      * Get number of total blocks in the mixture across all polymers.
+      */
+      int nBlock() const;
+
       /**
       * Get number of solvent (point particle) species.
       */
       int nSolvent() const;
-
-      /** 
-      * Get number of total pieces in the mixture (each block is
-      * its own piece, and each solvent is its own piece).
-      */
-      int nPieces() const;
 
       //@}
 
@@ -169,10 +168,9 @@ namespace Pscf
       int nSolvent_;
 
       /**
-      * Number of pieces in the system (each block and
-      * each solvent is its own piece).
+      * Number of blocks total, across all polymers.
       */
-      int nPieces_;
+      int nBlock_;
 
    };
 
@@ -191,8 +189,8 @@ namespace Pscf
    {  return nSolvent_; }
 
    template <class TP, class TS>
-   inline int MixtureTmpl<TP,TS>::nPieces() const
-   {  return nPieces_; }
+   inline int MixtureTmpl<TP,TS>::nBlock() const
+   {  return nBlock_; }
 
    template <class TP, class TS>
    inline Monomer const & MixtureTmpl<TP,TS>::monomer(int id) const
@@ -250,7 +248,7 @@ namespace Pscf
       nMonomer_(0), 
       nPolymer_(0),
       nSolvent_(0),
-      nPieces_(0)
+      nBlock_(0)
    {}
 
    /*
@@ -282,7 +280,7 @@ namespace Pscf
       * Monomer::kuhn on a single line.
       */
 
-      // Read nPolymer and (optionally) nSolvent, with nSolvent=0 by default
+      // Read nPolymer
       read<int>(in, "nPolymer", nPolymer_);
       UTIL_CHECK(nPolymer_ > 0);
 
@@ -290,14 +288,14 @@ namespace Pscf
       nSolvent_ = 0;
       readOptional<int>(in, "nSolvent", nSolvent_);
 
-      // Read polymers and compute nPieces_
-      nPieces_ = nSolvent_;
+      // Read polymers and compute nBlock
+      nBlock_ = 0;
       if (nPolymer_ > 0) {
 
          polymers_.allocate(nPolymer_);
          for (int i = 0; i < nPolymer_; ++i) {
             readParamComposite(in, polymer(i));
-            nPieces_ = nPieces_ + polymer(i).nBlock();
+            nBlock_ = nBlock_ + polymer(i).nBlock();
          }
    
          // Set statistical segment lengths for all blocks

--- a/src/pscf/solvers/MixtureTmpl.h
+++ b/src/pscf/solvers/MixtureTmpl.h
@@ -115,6 +115,12 @@ namespace Pscf
       */
       int nSolvent() const;
 
+      /** 
+      * Get number of total pieces in the mixture (each block is
+      * its own piece, and each solvent is its own piece).
+      */
+      int nPieces() const;
+
       //@}
 
    protected:
@@ -162,6 +168,12 @@ namespace Pscf
       */
       int nSolvent_;
 
+      /**
+      * Number of pieces in the system (each block and
+      * each solvent is its own piece).
+      */
+      int nPieces_;
+
    };
 
    // Inline member functions
@@ -177,6 +189,10 @@ namespace Pscf
    template <class TP, class TS>
    inline int MixtureTmpl<TP,TS>::nSolvent() const
    {  return nSolvent_; }
+
+   template <class TP, class TS>
+   inline int MixtureTmpl<TP,TS>::nPieces() const
+   {  return nPieces_; }
 
    template <class TP, class TS>
    inline Monomer const & MixtureTmpl<TP,TS>::monomer(int id) const
@@ -233,7 +249,8 @@ namespace Pscf
       solvents_(),
       nMonomer_(0), 
       nPolymer_(0),
-      nSolvent_(0)
+      nSolvent_(0),
+      nPieces_(0)
    {}
 
    /*
@@ -273,12 +290,14 @@ namespace Pscf
       nSolvent_ = 0;
       readOptional<int>(in, "nSolvent", nSolvent_);
 
-      // Read polymers
+      // Read polymers and compute nPieces_
+      nPieces_ = nSolvent_;
       if (nPolymer_ > 0) {
 
          polymers_.allocate(nPolymer_);
          for (int i = 0; i < nPolymer_; ++i) {
             readParamComposite(in, polymer(i));
+            nPieces_ = nPieces_ + polymer(i).nBlock();
          }
    
          // Set statistical segment lengths for all blocks

--- a/src/pspc/System.h
+++ b/src/pspc/System.h
@@ -262,6 +262,23 @@ namespace Pspc
       //@{
 
       /**
+      * Get array of all block/solvent concentration fields on r-space 
+      * grid.
+      *
+      * The array capacity is equal to nPieces, the number of total 
+      * blocks in the system plus nSolvents.
+      */
+      DArray<CField>& cFieldsRGridLong();
+
+      /**
+      * Get concentration field for one block/solvent on r-space grid.
+      *
+      * \param sectionId integer piece (block or solvent) index
+      */
+      CField& cFieldRGridLong(int sectionId);
+
+
+      /**
       * Get UnitCell (i.e., type and parameters) by const reference.
       */
       UnitCell<D> const & unitCell() const;
@@ -469,6 +486,14 @@ namespace Pspc
       void writeCRGrid(const std::string & filename) const;
 
       /**
+      * Write concentration fields in real space (r-grid) format, for each
+      * "piece" (block or solvent) individually rather than for each species.
+      *
+      * \param filename name of output file
+      */
+      void writeCRGridLong(const std::string & filename);
+
+      /**
       * Write last contour slice of the propagator in real space grid format.
       *
       * \param filename name of output file
@@ -634,6 +659,18 @@ namespace Pspc
       * Indexed by monomer typeId, size = nMonomer.
       */
       DArray<CField> cFieldsRGrid_;
+
+      /**
+      * Array of concentration fields for each piece (a single 
+      * block or solvent) on real space grid.
+      *
+      * The order is determined by first looping through each 
+      * Polymer object in the Mixture & looping over each Block 
+      * in the Polymer object. Then, Solvent objects in the 
+      * Mixture are looped over at the end.
+      */
+      DArray<CField> cFieldsRGridLong_;
+
 
       /**
       * Work array of field coefficients for all monomer types.
@@ -860,6 +897,17 @@ namespace Pspc
    inline typename System<D>::CField const & System<D>::cFieldRGrid(int id)
    const
    {  return cFieldsRGrid_[id]; }
+
+   // Get array of all block/solvent concentration fields on grids.
+   template <int D>
+   inline
+   DArray< typename System<D>::CField >& System<D>::cFieldsRGridLong()
+   {  return cFieldsRGridLong_; }
+
+   // Get a single block/solvent concentration field on an r-space grid.
+   template <int D>
+   inline typename System<D>::CField& System<D>::cFieldRGridLong(int id)
+   {  return cFieldsRGridLong_[id]; }
 
    // Have the w fields been set?
    template <int D>

--- a/src/pspc/System.h
+++ b/src/pspc/System.h
@@ -257,26 +257,29 @@ namespace Pspc
       */
       CField const & cFieldRGrid(int monomerId) const;
 
-      //@}
-      /// \name Miscellaneous Accessors 
-      //@{
-
       /**
-      * Get array of all block/solvent concentration fields on r-space 
-      * grid.
+      * Get array of all individual block/solvent concentration fields
+      * on r-space grid.
       *
       * The array capacity is equal to nPieces, the number of total 
-      * blocks in the system plus nSolvents.
+      * blocks in the system plus nSolvents. The order of CFields is 
+      * determined by looping over each Polymer object in the Mixture,
+      * and storing the CField for each Block in that Polymer in order.
+      * Then, we loop over Solvent objects in the Mixture and store a 
+      * CField for each. 
       */
-      DArray<CField>& cFieldsRGridLong();
+      DArray<CField> const cFieldsRGridLong() const;
 
       /**
       * Get concentration field for one block/solvent on r-space grid.
       *
       * \param sectionId integer piece (block or solvent) index
       */
-      CField& cFieldRGridLong(int sectionId);
+      CField const cFieldRGridLong(int sectionId) const;
 
+      //@}
+      /// \name Miscellaneous Accessors 
+      //@{
 
       /**
       * Get UnitCell (i.e., type and parameters) by const reference.
@@ -491,7 +494,7 @@ namespace Pspc
       *
       * \param filename name of output file
       */
-      void writeCRGridLong(const std::string & filename);
+      void writeCRGridLong(const std::string & filename) const;
 
       /**
       * Write last contour slice of the propagator in real space grid format.
@@ -659,18 +662,6 @@ namespace Pspc
       * Indexed by monomer typeId, size = nMonomer.
       */
       DArray<CField> cFieldsRGrid_;
-
-      /**
-      * Array of concentration fields for each piece (a single 
-      * block or solvent) on real space grid.
-      *
-      * The order is determined by first looping through each 
-      * Polymer object in the Mixture & looping over each Block 
-      * in the Polymer object. Then, Solvent objects in the 
-      * Mixture are looped over at the end.
-      */
-      DArray<CField> cFieldsRGridLong_;
-
 
       /**
       * Work array of field coefficients for all monomer types.
@@ -901,13 +892,15 @@ namespace Pspc
    // Get array of all block/solvent concentration fields on grids.
    template <int D>
    inline
-   DArray< typename System<D>::CField >& System<D>::cFieldsRGridLong()
-   {  return cFieldsRGridLong_; }
+   DArray< typename System<D>::CField > const System<D>::cFieldsRGridLong()
+   const
+   {  return mixture_.createRGridLong(); }
 
    // Get a single block/solvent concentration field on an r-space grid.
    template <int D>
-   inline typename System<D>::CField& System<D>::cFieldRGridLong(int id)
-   {  return cFieldsRGridLong_[id]; }
+   inline typename System<D>::CField const System<D>::cFieldRGridLong(int id)
+   const
+   {  return mixture_.createRGridLong()[id]; }
 
    // Have the w fields been set?
    template <int D>

--- a/src/pspc/System.h
+++ b/src/pspc/System.h
@@ -257,26 +257,6 @@ namespace Pspc
       */
       CField const & cFieldRGrid(int monomerId) const;
 
-      /**
-      * Get array of all individual block/solvent concentration fields
-      * on r-space grid.
-      *
-      * The array capacity is equal to nPieces, the number of total 
-      * blocks in the system plus nSolvents. The order of CFields is 
-      * determined by looping over each Polymer object in the Mixture,
-      * and storing the CField for each Block in that Polymer in order.
-      * Then, we loop over Solvent objects in the Mixture and store a 
-      * CField for each. 
-      */
-      DArray<CField> const cFieldsRGridLong() const;
-
-      /**
-      * Get concentration field for one block/solvent on r-space grid.
-      *
-      * \param sectionId integer piece (block or solvent) index
-      */
-      CField const cFieldRGridLong(int sectionId) const;
-
       //@}
       /// \name Miscellaneous Accessors 
       //@{
@@ -490,11 +470,11 @@ namespace Pspc
 
       /**
       * Write concentration fields in real space (r-grid) format, for each
-      * "piece" (block or solvent) individually rather than for each species.
+      * block (or solvent) individually rather than for each species.
       *
       * \param filename name of output file
       */
-      void writeCRGridLong(const std::string & filename) const;
+      void writeBlockCRGrid(const std::string & filename) const;
 
       /**
       * Write last contour slice of the propagator in real space grid format.
@@ -888,19 +868,6 @@ namespace Pspc
    inline typename System<D>::CField const & System<D>::cFieldRGrid(int id)
    const
    {  return cFieldsRGrid_[id]; }
-
-   // Get array of all block/solvent concentration fields on grids.
-   template <int D>
-   inline
-   DArray< typename System<D>::CField > const System<D>::cFieldsRGridLong()
-   const
-   {  return mixture_.createRGridLong(); }
-
-   // Get a single block/solvent concentration field on an r-space grid.
-   template <int D>
-   inline typename System<D>::CField const System<D>::cFieldRGridLong(int id)
-   const
-   {  return mixture_.createRGridLong()[id]; }
 
    // Have the w fields been set?
    template <int D>

--- a/src/pspc/System.tpp
+++ b/src/pspc/System.tpp
@@ -257,13 +257,11 @@ namespace Pspc
 
       // Allocate wFields and cFields
       int nMonomer = mixture_.nMonomer();
-      int nPieces = mixture_.nPieces();
       wFields_.allocate(nMonomer);
       wFieldsRGrid_.allocate(nMonomer);
 
       cFields_.allocate(nMonomer);
       cFieldsRGrid_.allocate(nMonomer);
-      cFieldsRGridLong_.allocate(nPieces);
       
       tmpFields_.allocate(nMonomer);
       tmpFieldsRGrid_.allocate(nMonomer);
@@ -279,10 +277,6 @@ namespace Pspc
          tmpFields_[i].allocate(basis().nBasis());
          tmpFieldsRGrid_[i].allocate(mesh().dimensions());
          tmpFieldsKGrid_[i].allocate(mesh().dimensions());
-      }
-
-      for (int i = 0; i < nPieces; ++i) {
-         cFieldsRGridLong_[i].allocate(mesh().dimensions());
       }
 
       isAllocated_ = true;
@@ -780,9 +774,6 @@ namespace Pspc
       fieldIo().convertRGridToBasis(cFieldsRGrid_, cFields_);
       hasCFields_ = true;
 
-      // Get c fields on r-grid for each block/solvent individually
-      mixture_.createRGridLong(cFieldsRGridLong_);
-
       if (needStress) {
          mixture_.computeStress();
       }
@@ -907,10 +898,11 @@ namespace Pspc
    * "piece" (block or solvent) individually rather than for each species.
    */
    template <int D>
-   void System<D>::writeCRGridLong(const std::string & filename)
+   void System<D>::writeCRGridLong(const std::string & filename) const
    {
       UTIL_CHECK(hasCFields_);
-      fieldIo().writeFieldsRGrid(filename, cFieldsRGridLong_, unitCell());
+      DArray<CField> cFieldsLong = cFieldsRGridLong();
+      fieldIo().writeFieldsRGrid(filename, cFieldsLong, unitCell());
    }
 
    /*

--- a/src/pspc/solvers/Mixture.h
+++ b/src/pspc/solvers/Mixture.h
@@ -160,13 +160,13 @@ namespace Pspc
       void computeStress();
 
       /**
-       * Combine cFields for each polymer/solvent into one DArray, which 
+       * Combine cFields for each block/solvent into one DArray, which 
        * is used in System.tpp to print a more detailed r-grid file using
        * the command WRITE_C_RGRID_LONG.
        * 
        * \param cFieldsLong array of block/solvent concentration fields (output)
        */
-      void createRGridLong(DArray<CField>& cFieldsLong);
+      DArray<CField> const createRGridLong() const;
 
       /**
       * Get derivative of free energy w/ respect to a unit cell parameter.

--- a/src/pspc/solvers/Mixture.h
+++ b/src/pspc/solvers/Mixture.h
@@ -160,13 +160,13 @@ namespace Pspc
       void computeStress();
 
       /**
-       * Combine cFields for each block/solvent into one DArray, which 
-       * is used in System.tpp to print a more detailed r-grid file using
-       * the command WRITE_C_RGRID_LONG.
-       * 
-       * \param cFieldsLong array of block/solvent concentration fields (output)
-       */
-      DArray<CField> const createRGridLong() const;
+      * Combine cFields for each block/solvent into one DArray, which 
+      * is used in System.tpp to print a more detailed r-grid file using
+      * the command WRITE_C_BLOCK_RGRID.
+      * 
+      * \param blockCFields empty but allocated DArray to store fields
+      */
+      void createBlockCRGrid(DArray<CField>& blockCFields) const;
 
       /**
       * Get derivative of free energy w/ respect to a unit cell parameter.
@@ -196,7 +196,7 @@ namespace Pspc
       using MixtureTmpl< Polymer<D>, Solvent<D> >::nMonomer;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::nPolymer;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::nSolvent;
-      using MixtureTmpl< Polymer<D>, Solvent<D> >::nPieces;
+      using MixtureTmpl< Polymer<D>, Solvent<D> >::nBlock;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::polymer;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::monomer;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::solvent;

--- a/src/pspc/solvers/Mixture.h
+++ b/src/pspc/solvers/Mixture.h
@@ -160,6 +160,15 @@ namespace Pspc
       void computeStress();
 
       /**
+       * Combine cFields for each polymer/solvent into one DArray, which 
+       * is used in System.tpp to print a more detailed r-grid file using
+       * the command WRITE_C_RGRID_LONG.
+       * 
+       * \param cFieldsLong array of block/solvent concentration fields (output)
+       */
+      void createRGridLong(DArray<CField>& cFieldsLong);
+
+      /**
       * Get derivative of free energy w/ respect to a unit cell parameter.
       *
       * Get the pre-computed derivative with respect to unit cell 
@@ -187,6 +196,7 @@ namespace Pspc
       using MixtureTmpl< Polymer<D>, Solvent<D> >::nMonomer;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::nPolymer;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::nSolvent;
+      using MixtureTmpl< Polymer<D>, Solvent<D> >::nPieces;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::polymer;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::monomer;
       using MixtureTmpl< Polymer<D>, Solvent<D> >::solvent;

--- a/src/pspc/solvers/Mixture.tpp
+++ b/src/pspc/solvers/Mixture.tpp
@@ -240,19 +240,26 @@ namespace Pspc
    * Combine cFields for each polymer/solvent into one DArray
    */
    template <int D>
-   void
-   Mixture<D>::createRGridLong(DArray<Mixture<D>::CField>& cFieldsLong)
+   DArray<typename Mixture<D>::CField> const 
+   Mixture<D>::createRGridLong() const
    {
       UTIL_CHECK(nMonomer() > 0);
       UTIL_CHECK(nPolymer() + nSolvent() > 0);
-      UTIL_CHECK(cFieldsLong.capacity() == nPieces());
 
+      int np = nPieces();
       int nx = mesh().size();
-      int ns = nPieces();
       int i, j;
 
+      DArray<CField> cFieldsLong;
+      cFieldsLong.allocate(np);
+      for (i = 0; i < np; ++i) {
+         cFieldsLong[i].allocate(mesh().dimensions());
+      }
+
+      UTIL_CHECK(cFieldsLong.capacity() == nPieces());
+
       // Clear all monomer concentration fields, check capacities
-      for (i = 0; i < ns; ++i) {
+      for (i = 0; i < np; ++i) {
          UTIL_CHECK(cFieldsLong[i].capacity() == nx);
          for (j = 0; j < nx; ++j) {
             cFieldsLong[i][j] = 0.0;
@@ -270,7 +277,7 @@ namespace Pspc
                sectionId++;
 
                UTIL_CHECK(sectionId >= 0);
-               UTIL_CHECK(sectionId < ns);
+               UTIL_CHECK(sectionId < np);
                UTIL_CHECK(cFieldsLong[sectionId].capacity() == nx);
 
                cFieldsLong[sectionId] = polymer(i).block(j).cField();
@@ -286,15 +293,13 @@ namespace Pspc
             sectionId++;
 
             UTIL_CHECK(sectionId >= 0);
-            UTIL_CHECK(sectionId < ns);
+            UTIL_CHECK(sectionId < np);
             UTIL_CHECK(cFieldsLong[sectionId].capacity() == nx);
 
             cFieldsLong[sectionId] = solvent(i).cField();
-
          }
-
       }
-
+   return cFieldsLong;
    }
 
 } // namespace Pspc

--- a/src/pspc/solvers/Mixture.tpp
+++ b/src/pspc/solvers/Mixture.tpp
@@ -237,50 +237,45 @@ namespace Pspc
    }
 
    /*
-   * Combine cFields for each polymer/solvent into one DArray
+   * Combine cFields for each block (and solvent) into one DArray
    */
    template <int D>
-   DArray<typename Mixture<D>::CField> const 
-   Mixture<D>::createRGridLong() const
+   void
+   Mixture<D>::createBlockCRGrid(DArray<typename Mixture<D>::CField>& blockCFields) 
+   const
    {
       UTIL_CHECK(nMonomer() > 0);
-      UTIL_CHECK(nPolymer() + nSolvent() > 0);
+      UTIL_CHECK(nBlock() + nSolvent() > 0);
 
-      int np = nPieces();
+      int np = nSolvent() + nBlock();
       int nx = mesh().size();
       int i, j;
 
-      DArray<CField> cFieldsLong;
-      cFieldsLong.allocate(np);
-      for (i = 0; i < np; ++i) {
-         cFieldsLong[i].allocate(mesh().dimensions());
-      }
-
-      UTIL_CHECK(cFieldsLong.capacity() == nPieces());
+      UTIL_CHECK(blockCFields.capacity() == nBlock() + nSolvent());
 
       // Clear all monomer concentration fields, check capacities
       for (i = 0; i < np; ++i) {
-         UTIL_CHECK(cFieldsLong[i].capacity() == nx);
+         UTIL_CHECK(blockCFields[i].capacity() == nx);
          for (j = 0; j < nx; ++j) {
-            cFieldsLong[i][j] = 0.0;
+            blockCFields[i][j] = 0.0;
          }
       }
 
       // Process polymer species
-      int sectionId(-1);
+      int sectionId = -1;
 
       if (nPolymer() > 0) {
 
-         // Write each block's r-grid data to cFieldsLong
+         // Write each block's r-grid data to blockCFields
          for (i = 0; i < nPolymer(); ++i) {
             for (j = 0; j < polymer(i).nBlock(); ++j) {
                sectionId++;
 
                UTIL_CHECK(sectionId >= 0);
                UTIL_CHECK(sectionId < np);
-               UTIL_CHECK(cFieldsLong[sectionId].capacity() == nx);
+               UTIL_CHECK(blockCFields[sectionId].capacity() == nx);
 
-               cFieldsLong[sectionId] = polymer(i).block(j).cField();
+               blockCFields[sectionId] = polymer(i).block(j).cField();
             }
          }
       }
@@ -288,18 +283,17 @@ namespace Pspc
       // Process solvent species
       if (nSolvent() > 0) {
 
-         // Write each solvent's r-grid data to cFieldsLong
+         // Write each solvent's r-grid data to blockCFields
          for (i = 0; i < nSolvent(); ++i) {
             sectionId++;
 
             UTIL_CHECK(sectionId >= 0);
             UTIL_CHECK(sectionId < np);
-            UTIL_CHECK(cFieldsLong[sectionId].capacity() == nx);
+            UTIL_CHECK(blockCFields[sectionId].capacity() == nx);
 
-            cFieldsLong[sectionId] = solvent(i).cField();
+            blockCFields[sectionId] = solvent(i).cField();
          }
       }
-   return cFieldsLong;
    }
 
 } // namespace Pspc

--- a/src/pspc/solvers/Mixture.tpp
+++ b/src/pspc/solvers/Mixture.tpp
@@ -236,6 +236,67 @@ namespace Pspc
       return true;
    }
 
+   /*
+   * Combine cFields for each polymer/solvent into one DArray
+   */
+   template <int D>
+   void
+   Mixture<D>::createRGridLong(DArray<Mixture<D>::CField>& cFieldsLong)
+   {
+      UTIL_CHECK(nMonomer() > 0);
+      UTIL_CHECK(nPolymer() + nSolvent() > 0);
+      UTIL_CHECK(cFieldsLong.capacity() == nPieces());
+
+      int nx = mesh().size();
+      int ns = nPieces();
+      int i, j;
+
+      // Clear all monomer concentration fields, check capacities
+      for (i = 0; i < ns; ++i) {
+         UTIL_CHECK(cFieldsLong[i].capacity() == nx);
+         for (j = 0; j < nx; ++j) {
+            cFieldsLong[i][j] = 0.0;
+         }
+      }
+
+      // Process polymer species
+      int sectionId(-1);
+
+      if (nPolymer() > 0) {
+
+         // Write each block's r-grid data to cFieldsLong
+         for (i = 0; i < nPolymer(); ++i) {
+            for (j = 0; j < polymer(i).nBlock(); ++j) {
+               sectionId++;
+
+               UTIL_CHECK(sectionId >= 0);
+               UTIL_CHECK(sectionId < ns);
+               UTIL_CHECK(cFieldsLong[sectionId].capacity() == nx);
+
+               cFieldsLong[sectionId] = polymer(i).block(j).cField();
+            }
+         }
+      }
+
+      // Process solvent species
+      if (nSolvent() > 0) {
+
+         // Write each solvent's r-grid data to cFieldsLong
+         for (i = 0; i < nSolvent(); ++i) {
+            sectionId++;
+
+            UTIL_CHECK(sectionId >= 0);
+            UTIL_CHECK(sectionId < ns);
+            UTIL_CHECK(cFieldsLong[sectionId].capacity() == nx);
+
+            cFieldsLong[sectionId] = solvent(i).cField();
+
+         }
+
+      }
+
+   }
+
 } // namespace Pspc
 } // namespace Pscf
 #endif

--- a/src/pspg/System.h
+++ b/src/pspg/System.h
@@ -450,6 +450,14 @@ namespace Pspg
       void writeCBasis(const std::string & filename);
 
       /**
+      * Write concentration fields in real space (r-grid) format, for each
+      * block (or solvent) individually rather than for each species.
+      *
+      * \param filename name of output file
+      */
+      void writeBlockCRGrid(const std::string & filename) const;
+
+      /**
       * Write last contour slice of the propagator in real space grid format.
       *
       * \param filename name of output file

--- a/src/pspg/System.h
+++ b/src/pspg/System.h
@@ -263,6 +263,16 @@ namespace Pspg
       Mesh<D> & mesh();
 
       /**
+      * Get spatial discretization mesh by const reference.
+      */
+      Mesh<D> const & mesh() const;
+
+      /**
+      * Get crystal unitCell (i.e., lattice type and parameters) by const reference.
+      */
+      UnitCell<D> const & unitCell() const;
+
+      /**
       * Get crystal unitCell (i.e., lattice type and parameters) by reference.
       */
       UnitCell<D> & unitCell();
@@ -293,12 +303,12 @@ namespace Pspg
       WaveList<D>& wavelist();
 
       /**
-      * Get associated FieldIo object.
+      * Get associated const FieldIo object.
       */
-      FieldIo<D> & fieldIo();
+      FieldIo<D> const & fieldIo() const;
 
       /**
-      * Get associated FFT objecti by reference.
+      * Get associated FFT object by reference.
       */
       FFT<D> & fft();
 
@@ -681,9 +691,18 @@ namespace Pspg
    inline UnitCell<D> & System<D>::unitCell()
    { return domain_.unitCell(); }
 
-   // Get the Mesh<D> object.
+   template <int D>
+   inline UnitCell<D> const & System<D>::unitCell() const
+   { return domain_.unitCell(); }
+
+   // get the Mesh<D> object.
    template <int D>
    inline Mesh<D> & System<D>::mesh()
+   { return domain_.mesh(); }
+
+   // get the const Mesh<D> object.
+   template <int D>
+   inline Mesh<D> const & System<D>::mesh() const
    { return domain_.mesh(); }
 
    // Get the Basis<D> object.
@@ -696,9 +715,9 @@ namespace Pspg
    inline FFT<D> & System<D>::fft()
    {  return domain_.fft(); }
 
-   // Get the FieldIo<D> object.
+   // Get the const FieldIo<D> object.
    template <int D>
-   inline FieldIo<D> & System<D>::fieldIo()
+   inline FieldIo<D> const & System<D>::fieldIo() const
    {  return domain_.fieldIo(); }
 
    // Get the groupName string.

--- a/src/pspg/System.tpp
+++ b/src/pspg/System.tpp
@@ -134,7 +134,7 @@ namespace Pspg
             iArg  = optarg;
             break;
          case 'o': // output prefix
-            iFlag = true;
+            oFlag = true;
             oArg  = optarg;
             break;
          case 't': //number of threads per block, user set

--- a/src/pspg/System.tpp
+++ b/src/pspg/System.tpp
@@ -379,6 +379,10 @@ namespace Pspg
             readEcho(in, filename);
             fieldIo().writeFieldsRGrid(filename, cFieldsRGrid());
          } else 
+         if (command == "WRITE_C_BLOCK_RGRID") {
+            readEcho(in, filename);
+            writeBlockCRGrid(filename);
+         } else
          if (command == "WRITE_PROPAGATOR") {
             int polymerID, blockID;
             readEcho(in, filename);
@@ -803,6 +807,28 @@ namespace Pspg
    {
       UTIL_CHECK(hasCFields_);
       fieldIo().writeFieldsBasis(filename, cFields());
+   }
+
+   /*
+   * Write all concentration fields in real space (r-grid) format, for each
+   * block (or solvent) individually rather than for each species.
+   */
+   template <int D>
+   void System<D>::writeBlockCRGrid(const std::string & filename) const
+   {
+      UTIL_CHECK(hasCFields_);
+
+      // Create and allocate the DArray of fields to be written
+      DArray<CField> blockCFields;
+      blockCFields.allocate(mixture_.nSolvent() + mixture_.nBlock());
+      int n = blockCFields.capacity();
+      for (int i = 0; i < n; i++) {
+         blockCFields[i].allocate(mesh().dimensions());
+      }
+
+      // Get data from Mixture and write to file
+      mixture_.createBlockCRGrid(blockCFields);
+      fieldIo().writeFieldsRGrid(filename, blockCFields, unitCell());
    }
 
    template <int D>

--- a/src/pspg/System.tpp
+++ b/src/pspg/System.tpp
@@ -828,7 +828,7 @@ namespace Pspg
 
       // Get data from Mixture and write to file
       mixture_.createBlockCRGrid(blockCFields);
-      fieldIo().writeFieldsRGrid(filename, blockCFields, unitCell());
+      fieldIo().writeFieldsRGrid(filename, blockCFields);
    }
 
    template <int D>

--- a/src/pspg/field/FieldIo.h
+++ b/src/pspg/field/FieldIo.h
@@ -81,7 +81,7 @@ namespace Pspg
       * \param fields array of fields (symmetry adapted basis components)
       */
       void 
-      readFieldsBasis(std::istream& in, DArray< RDField <D> >& fields);
+      readFieldsBasis(std::istream& in, DArray< RDField <D> >& fields) const;
 
       /**
       * Read concentration or chemical potential field components from file.
@@ -94,7 +94,7 @@ namespace Pspg
       * \param fields array of fields (symmetry adapted basis components)
       */
       void readFieldsBasis(std::string filename, 
-                           DArray< RDField <D> >& fields);
+                           DArray< RDField <D> >& fields) const;
 
       /**
       * Write concentration or chemical potential field components to file.
@@ -105,7 +105,7 @@ namespace Pspg
       * \param fields array of fields (symmetry adapted basis components)
       */
       void writeFieldsBasis(std::ostream& out, 
-                            DArray< RDField <D> > const & fields);
+                            DArray< RDField <D> > const & fields) const;
 
       /**
       * Write concentration or chemical potential field components to file.
@@ -118,7 +118,7 @@ namespace Pspg
       * \param fields array of fields (symmetry adapted basis components)
       */
       void writeFieldsBasis(std::string filename, 
-                            DArray< RDField <D> > const & fields);
+                            DArray< RDField <D> > const & fields) const;
 
       /**
       * Read array of RField objects (fields on an r-space grid) from file.
@@ -129,7 +129,7 @@ namespace Pspg
       * \param in input stream (i.e., input file)
       * \param fields array of RField fields (r-space grid)
       */
-      void readFieldsRGrid(std::istream& in, DArray< RDField<D> >& fields);
+      void readFieldsRGrid(std::istream& in, DArray< RDField<D> >& fields) const;
 
       /**
       * Read array of RField objects (fields on an r-space grid) from file.
@@ -144,7 +144,8 @@ namespace Pspg
       * \param filename name of input file
       * \param fields array of RField fields (r-space grid)
       */
-      void readFieldsRGrid(std::string filename, DArray< RDField<D> >& fields);
+      void readFieldsRGrid(std::string filename, DArray< RDField<D> >& fields)
+      const;
 
       /**
       * Write array of RField objects (fields on an r-space grid) to file.
@@ -153,7 +154,7 @@ namespace Pspg
       * \param fields array of RField fields (r-space grid)
       */
       void writeFieldsRGrid(std::ostream& out, 
-                            DArray< RDField<D> > const& fields);
+                            DArray< RDField<D> > const& fields) const;
 
       /**
       * Write array of RField objects (fields on an r-space grid) to file.
@@ -166,16 +167,16 @@ namespace Pspg
       * \param fields  array of RField fields (r-space grid)
       */
       void writeFieldsRGrid(std::string filename,
-                            DArray< RDField<D> > const& fields);
+                            DArray< RDField<D> > const& fields) const;
 
 
-      void readFieldRGrid(std::istream& in, RDField<D> &field);
+      void readFieldRGrid(std::istream& in, RDField<D> &field) const;
 
-      void readFieldRGrid(std::string filename, RDField<D> &field);
+      void readFieldRGrid(std::string filename, RDField<D> &field) const;
 
-      void writeFieldRGrid(std::ostream& out, RDField<D> const & field);
+      void writeFieldRGrid(std::ostream& out, RDField<D> const & field) const;
 
-      void writeFieldRGrid(std::string filename, RDField<D> const & field);
+      void writeFieldRGrid(std::string filename, RDField<D> const & field) const;
 
       /**
       * Read array of RFieldDft objects (k-space fields) from file.
@@ -188,7 +189,7 @@ namespace Pspg
       * \param fields  array of RFieldDft fields (k-space grid)
       */
       void readFieldsKGrid(std::istream& in, 
-                           DArray< RDFieldDft<D> >& fields);
+                           DArray< RDFieldDft<D> >& fields) const;
 
       /**
       * Read array of RFieldDft objects (k-space fields) from file.
@@ -205,7 +206,7 @@ namespace Pspg
       * \param fields  array of RFieldDft fields (k-space grid)
       */
       void readFieldsKGrid(std::string filename, 
-                           DArray< RDFieldDft<D> >& fields);
+                           DArray< RDFieldDft<D> >& fields) const;
 
       /**
       * Write array of RFieldDft objects (k-space fields) to file.
@@ -218,7 +219,7 @@ namespace Pspg
       * \param fields array of RFieldDft fields 
       */
       void writeFieldsKGrid(std::ostream& out, 
-                            DArray< RDFieldDft<D> > const& fields);
+                            DArray< RDFieldDft<D> > const& fields) const;
    
       /**
       * Write array of RFieldDft objects (k-space fields) to a file.
@@ -231,7 +232,7 @@ namespace Pspg
       * \param fields  array of RFieldDft fields (k-space grid)
       */
       void writeFieldsKGrid(std::string filename, 
-                           DArray< RDFieldDft<D> > const& fields);
+                           DArray< RDFieldDft<D> > const& fields) const;
 
       /**
       * Write header for field file (fortran pscf format)
@@ -252,7 +253,7 @@ namespace Pspg
       * \param dft discrete Fourier transform of a real field
       */
       void convertBasisToKGrid(RDField<D> const& components, 
-                               RDFieldDft<D>& dft);
+                               RDFieldDft<D>& dft) const;
    
       /**
       * Convert fields from symmetrized basis to Fourier transform (kgrid).
@@ -264,7 +265,7 @@ namespace Pspg
       * \param out fields defined as discrete Fourier transforms (k-grid)
       */
       void convertBasisToKGrid(DArray< RDField <D> > & in,
-                               DArray< RDFieldDft<D> >& out);
+                               DArray< RDFieldDft<D> >& out) const;
 
       /**
       * Convert field from Fourier transform (k-grid) to symmetrized basis.
@@ -273,7 +274,7 @@ namespace Pspg
       * \param components coefficients of symmetry-adapted basis functions.
       */
       void convertKGridToBasis(RDFieldDft<D> const& dft, 
-                               RDField<D>& components);
+                               RDField<D>& components) const;
 
       /**
       * Convert fields from Fourier transform (kgrid) to symmetrized basis.
@@ -285,7 +286,7 @@ namespace Pspg
       * \param out  components of fields in symmetry adapted basis 
       */
       void convertKGridToBasis(DArray< RDFieldDft<D> > & in,
-                               DArray< RDField <D> > & out);
+                               DArray< RDField <D> > & out) const;
 
       /**
       * Convert fields from symmetrized basis to spatial grid (rgrid).
@@ -294,7 +295,7 @@ namespace Pspg
       * \param out fields defined on real-space grid
       */
       void convertBasisToRGrid(DArray< RDField <D> > & in,
-                               DArray< RDField<D> >& out);
+                               DArray< RDField<D> >& out) const;
 
       /**
       * Convert fields from spatial grid (rgrid) to symmetrized basis.
@@ -303,7 +304,7 @@ namespace Pspg
       * \param out  fields in symmetry adapted basis form
       */
       void convertRGridToBasis(DArray< RDField<D> > & in,
-                               DArray< RDField <D> > & out);
+                               DArray< RDField <D> > & out) const;
 
       /**
       * Convert fields from k-grid (DFT) to real space (rgrid) format.
@@ -332,7 +333,7 @@ namespace Pspg
    private:
 
       // DFT work array for two-step conversion basis <-> kgrid <-> rgrid.
-      RDFieldDft<D> workDft_;
+      mutable RDFieldDft<D> workDft_;
 
       // Pointers to associated objects.
 
@@ -340,43 +341,29 @@ namespace Pspg
       UnitCell<D>* unitCellPtr_;
 
       /// Pointer to spatial discretization mesh.
-      Mesh<D>* meshPtr_;
+      Mesh<D> const * meshPtr_;
 
       /// Pointer to FFT object.
-      FFT<D>* fftPtr_;
+      FFT<D> const * fftPtr_;
 
       /// Pointer to group name string
-      std::string* groupNamePtr_;
+      std::string const * groupNamePtr_;
 
       /// Pointer to a Basis object
-      Basis<D>* basisPtr_;
+      Basis<D> const * basisPtr_;
 
       /// Pointer to Filemaster (holds paths to associated I/O files).
-      FileMaster* fileMasterPtr_;
+      FileMaster const * fileMasterPtr_;
 
       // Private accessor functions:
 
       /// Get UnitCell by reference.
-      UnitCell<D>& unitCell()
+      UnitCell<D>& unitCell() const
       {  
          // UTIL_ASSERT(unitCellPtr_);  
          return *unitCellPtr_; 
       }
-
-      /// Get UnitCell by const reference.
-      UnitCell<D> const & unitCell() const
-      {  
-         // UTIL_ASSERT(unitCellPtr_);  
-         return *unitCellPtr_; 
-      }
-
-      /// Get spatial discretization mesh by reference.
-      Mesh<D>& mesh()
-      {  
-         // UTIL_ASSERT(meshPtr_);  
-         return *meshPtr_; 
-      }
-
+      
       /// Get spatial discretization mesh by const reference.
       Mesh<D> const & mesh() const
       {  
@@ -384,30 +371,26 @@ namespace Pspg
          return *meshPtr_; 
       }
 
-      /// Get FFT object by reference.
+      /// Get FFT object by const reference.
       FFT<D> const & fft() const
       {
          // UTIL_ASSERT(fftPtr_);  
          return *fftPtr_; 
       }
 
-      /// Get group name string by reference.
-      std::string& groupName()
-      {  return *groupNamePtr_; }
-
       /// Get group name string by const reference.
       std::string const & groupName() const
       {  return *groupNamePtr_; }
 
-      /// Get Basis by reference.
-      Basis<D>& basis()
+      /// Get Basis by const reference.
+      Basis<D> const & basis() const
       {
          // UTIL_ASSERT(basisPtr_);  
          return *basisPtr_; 
       }
 
-      /// Get FileMaster by reference.
-      FileMaster& fileMaster()
+      /// Get FileMaster by const reference.
+      FileMaster const & fileMaster() const
       {  
          UTIL_ASSERT(fileMasterPtr_);  
          return *fileMasterPtr_; 
@@ -418,12 +401,12 @@ namespace Pspg
       *
       * \param in input stream (i.e., input file)
       */
-      void readFieldHeader(std::istream& in);
+      void readFieldHeader(std::istream& in) const;
 
       /**
       * Check state of work array, allocate if necessary.
       */
-      void checkWorkDft();
+      void checkWorkDft() const;
 
    };
 

--- a/src/pspg/field/FieldIo.tpp
+++ b/src/pspg/field/FieldIo.tpp
@@ -69,6 +69,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::readFieldsBasis(std::istream& in, 
                                     DArray< RDField<D> >& fields)
+   const
    {
       int nMonomer = fields.capacity();
       UTIL_CHECK(nMonomer > 0);
@@ -148,6 +149,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::readFieldsBasis(std::string filename, 
                                     DArray<RDField<D> >& fields)
+   const
    {
        std::ifstream file;
        fileMaster().openInputFile(filename, file);
@@ -158,6 +160,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::writeFieldsBasis(std::ostream &out, 
                                      DArray<RDField<D> > const &  fields)
+   const
    {
       int nMonomer = fields.capacity();
       UTIL_CHECK(nMonomer > 0);
@@ -206,6 +209,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::writeFieldsBasis(std::string filename, 
                                      DArray<RDField<D> > const & fields)
+   const
    {
        std::ofstream file;
        fileMaster().openOutputFile(filename, file);
@@ -216,6 +220,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::readFieldsRGrid(std::istream &in,
                                     DArray<RDField<D> >& fields)
+   const
    {
       int nMonomer = fields.capacity();
       UTIL_CHECK(nMonomer > 0);
@@ -281,6 +286,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::readFieldsRGrid(std::string filename, 
                                     DArray< RDField<D> >& fields)
+   const
    {
       std::ifstream file;
       fileMaster().openInputFile(filename, file);
@@ -291,6 +297,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::writeFieldsRGrid(std::ostream &out,
                                      DArray<RDField<D> > const& fields)
+   const
    {
       int nMonomer = fields.capacity();
       UTIL_CHECK(nMonomer > 0);
@@ -351,6 +358,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::writeFieldsRGrid(std::string filename, 
                                      DArray< RDField<D> > const & fields)
+   const
    {
       std::ofstream file;
       fileMaster().openOutputFile(filename, file);
@@ -360,6 +368,7 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::readFieldRGrid(std::istream &in, RDField<D> &field)
+   const
    {
       FieldIo<D>::readFieldHeader(in);
 
@@ -414,6 +423,7 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::readFieldRGrid(std::string filename, RDField<D> &field)
+   const
    {
       std::ifstream file;
       fileMaster().openInputFile(filename, file);
@@ -423,6 +433,7 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::writeFieldRGrid(std::ostream &out, RDField<D> const & field)
+   const
    {
 
       writeFieldHeader(out, 1);
@@ -471,6 +482,7 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::writeFieldRGrid(std::string filename, RDField<D> const & field)
+   const
    {
       std::ofstream file;
       fileMaster().openOutputFile(filename, file);
@@ -481,6 +493,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::readFieldsKGrid(std::istream &in,
                                     DArray<RDFieldDft<D> >& fields)
+   const
    {
       int nMonomer = fields.capacity();
       UTIL_CHECK(nMonomer > 0);
@@ -533,6 +546,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::readFieldsKGrid(std::string filename, 
                                     DArray< RDFieldDft<D> >& fields)
+   const
    {
       std::ifstream file;
       fileMaster().openInputFile(filename, file);
@@ -543,6 +557,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::writeFieldsKGrid(std::ostream &out,
                                      DArray<RDFieldDft<D> > const& fields)
+   const
    {
       int nMonomer = fields.capacity();
       UTIL_CHECK(nMonomer > 0);
@@ -552,16 +567,16 @@ namespace Pspg
       out << "ngrid" << std::endl 
           << "               " << mesh().dimensions() << std::endl;
 
-     DArray<cudaComplex*> temp_out;
-     int kSize = 1;
-     for (int i = 0; i < D; i++) {
-        if (i == D - 1) {
-           kSize *= (mesh().dimension(i) / 2 + 1);
-        }
-        else {
-           kSize *= mesh().dimension(i);
-        }
-     }
+      DArray<cudaComplex*> temp_out;
+      int kSize = 1;
+      for (int i = 0; i < D; i++) {
+         if (i == D - 1) {
+            kSize *= (mesh().dimension(i) / 2 + 1);
+         }
+         else {
+            kSize *= mesh().dimension(i);
+         }
+      }
       temp_out.allocate(nMonomer);
       for(int i = 0; i < nMonomer; ++i) {
          temp_out[i] = new cudaComplex[kSize];
@@ -589,6 +604,7 @@ namespace Pspg
    template <int D>
    void FieldIo<D>::writeFieldsKGrid(std::string filename, 
                                      DArray< RDFieldDft<D> > const& fields)
+   const
    {
       std::ofstream file;
       fileMaster().openOutputFile(filename, file);
@@ -597,7 +613,7 @@ namespace Pspg
    }
 
    template <int D>
-   void FieldIo<D>::readFieldHeader(std::istream& in) 
+   void FieldIo<D>::readFieldHeader(std::istream& in) const
    {
       std::string label;
 
@@ -641,26 +657,26 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::convertBasisToKGrid(RDField<D> const& components, 
-                                        RDFieldDft<D>& dft)
+                                        RDFieldDft<D>& dft) const
    {
-     cudaReal* components_in;
-     components_in = new cudaReal[basis().nStar()];
-     cudaMemcpy(components_in, components.cDField(),
-            basis().nStar() * sizeof(cudaReal), cudaMemcpyDeviceToHost);
+      cudaReal* components_in;
+      components_in = new cudaReal[basis().nStar()];
+      cudaMemcpy(components_in, components.cDField(),
+             basis().nStar() * sizeof(cudaReal), cudaMemcpyDeviceToHost);
 
-     int kSize = 1;
-     for (int i = 0; i < D; i++) {
-        if (i == D - 1) {
-           kSize *= (mesh().dimension(i) / 2 + 1); 
-        }   
-        else {
-           kSize *= mesh().dimension(i);
-        }   
-     }   
-     cudaComplex* dft_out;
-     dft_out = new cudaComplex[kSize];
+      int kSize = 1;
+      for (int i = 0; i < D; i++) {
+         if (i == D - 1) {
+            kSize *= (mesh().dimension(i) / 2 + 1); 
+         }   
+         else {
+            kSize *= mesh().dimension(i);
+         }   
+      }   
+      cudaComplex* dft_out;
+      dft_out = new cudaComplex[kSize];
 
-   // Create Mesh<D> with dimensions of DFT Fourier grid.
+      // Create Mesh<D> with dimensions of DFT Fourier grid.
       Mesh<D> dftMesh(dft.dftDimensions());
 
       typename Basis<D>::Star const* starPtr; // pointer to current star
@@ -758,24 +774,24 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::convertKGridToBasis(RDFieldDft<D> const& dft, 
-                                        RDField<D>& components)
+                                        RDField<D>& components) const
    {
-     cudaReal* components_out;
-     components_out = new cudaReal[basis().nStar()];
+      cudaReal* components_out;
+      components_out = new cudaReal[basis().nStar()];
 
-     int kSize = 1;
-     for (int i = 0; i < D; i++) {
-        if (i == D - 1) {
-           kSize *= (mesh().dimension(i) / 2 + 1); 
-        }   
-        else {
-           kSize *= mesh().dimension(i);
-        }   
-     }   
-     cudaComplex* dft_in;
-     dft_in = new cudaComplex[kSize];
-     cudaMemcpy(dft_in, dft.cDField(),
-            kSize * sizeof(cudaComplex), cudaMemcpyDeviceToHost);
+      int kSize = 1;
+      for (int i = 0; i < D; i++) {
+         if (i == D - 1) {
+            kSize *= (mesh().dimension(i) / 2 + 1); 
+         }   
+         else {
+            kSize *= mesh().dimension(i);
+         }   
+      }   
+      cudaComplex* dft_in;
+      dft_in = new cudaComplex[kSize];
+      cudaMemcpy(dft_in, dft.cDField(),
+             kSize * sizeof(cudaComplex), cudaMemcpyDeviceToHost);
 
       // Create Mesh<D> with dimensions of DFT Fourier grid.
       Mesh<D> dftMesh(dft.dftDimensions());
@@ -872,7 +888,7 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::convertBasisToKGrid(DArray< RDField <D> >& in,
-                                        DArray< RDFieldDft<D> >& out)
+                                        DArray< RDFieldDft<D> >& out) const
    {
       UTIL_ASSERT(in.capacity() == out.capacity());
       int n = in.capacity();
@@ -968,7 +984,7 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::convertKGridToBasis(DArray< RDFieldDft<D> >& in,
-                                        DArray< RDField <D> > & out)
+                                        DArray< RDField <D> > & out) const
    {
 
       UTIL_ASSERT(in.capacity() == out.capacity());
@@ -983,7 +999,7 @@ namespace Pspg
    template <int D>
    void 
    FieldIo<D>::convertBasisToRGrid(DArray< RDField<D> >& in,
-                                   DArray< RDField<D> >& out)
+                                   DArray< RDField<D> >& out) const
    {
       UTIL_ASSERT(in.capacity() == out.capacity());
       //checkWorkDft();
@@ -1007,7 +1023,7 @@ namespace Pspg
    template <int D>
    void 
    FieldIo<D>::convertRGridToBasis(DArray< RDField<D> >& in,
-                                   DArray< RDField<D> > & out)
+                                   DArray< RDField<D> > & out) const
    {
       UTIL_ASSERT(in.capacity() == out.capacity());
       //checkWorkDft();
@@ -1056,7 +1072,7 @@ namespace Pspg
    }
 
    template <int D>
-   void FieldIo<D>::checkWorkDft()
+   void FieldIo<D>::checkWorkDft() const
    {
       if (!workDft_.isAllocated()) {
          workDft_.allocate(mesh().dimensions());

--- a/src/pspg/solvers/Mixture.h
+++ b/src/pspg/solvers/Mixture.h
@@ -128,6 +128,15 @@ namespace Pspg
       void computeStress(WaveList<D>& wavelist);
 
       /**
+      * Combine cFields for each block/solvent into one DArray, which 
+      * is used in System.tpp to print a more detailed r-grid file using
+      * the command WRITE_C_BLOCK_RGRID.
+      * 
+      * \param blockCFields empty but allocated DArray to store fields
+      */
+      void createBlockCRGrid(DArray<CField>& blockCFields) const;
+
+      /**
       * Get derivative of free energy w/ respect to cell parameter.
       *
       * Get precomputed value of derivative of free energy per monomer
@@ -152,6 +161,7 @@ namespace Pspg
       using MixtureTmpl< Pscf::Pspg::Polymer<D>, Pscf::Pspg::Solvent<D> >::nMonomer;
       using MixtureTmpl< Pscf::Pspg::Polymer<D>, Pscf::Pspg::Solvent<D> >::nPolymer;
       using MixtureTmpl< Pscf::Pspg::Polymer<D>, Pscf::Pspg::Solvent<D> >::nSolvent;
+      using MixtureTmpl< Pscf::Pspg::Polymer<D>, Pscf::Pspg::Solvent<D> >::nBlock;
       using MixtureTmpl< Pscf::Pspg::Polymer<D>, Pscf::Pspg::Solvent<D> >::polymer;
       using MixtureTmpl< Pscf::Pspg::Polymer<D>, Pscf::Pspg::Solvent<D> >::monomer;
       using MixtureTmpl< Pscf::Pspg::Polymer<D>, Pscf::Pspg::Solvent<D> >::solvent;

--- a/src/pspg/solvers/Mixture.tpp
+++ b/src/pspg/solvers/Mixture.tpp
@@ -189,6 +189,70 @@ namespace Pspg
       return true;
    }
 
+   /*
+   * Combine cFields for each block (and solvent) into one DArray
+   */
+   template <int D>
+   void
+   Mixture<D>::createBlockCRGrid(DArray<typename Mixture<D>::CField>& blockCFields) 
+   const
+   {
+      UTIL_CHECK(nMonomer() > 0);
+      UTIL_CHECK(nBlock() + nSolvent() > 0);
+
+      int np = nSolvent() + nBlock();
+      int nx = mesh().size();
+      int i, j;
+
+      UTIL_CHECK(blockCFields.capacity() == nBlock() + nSolvent());
+
+      // Clear all monomer concentration fields, check capacities
+      for (i = 0; i < np; ++i) {
+         UTIL_CHECK(blockCFields[i].capacity() == nx);
+         for (j = 0; j < nx; ++j) {
+            blockCFields[i][j] = 0.0;
+         }
+      }
+
+      // Process polymer species
+      int sectionId = -1;
+
+      if (nPolymer() > 0) {
+
+         // Write each block's r-grid data to blockCFields
+         for (i = 0; i < nPolymer(); ++i) {
+            for (j = 0; j < polymer(i).nBlock(); ++j) {
+               sectionId++;
+
+               UTIL_CHECK(sectionId >= 0);
+               UTIL_CHECK(sectionId < np);
+               UTIL_CHECK(blockCFields[sectionId].capacity() == nx);
+
+               const cudaReal* blockField = polymer(i).block(j).cField();
+               cudaMemcpy(blockCFields[sectionID].cDField(), blockField, 
+                          mesh().size() * sizeof(cudaReal), cudaMemcpyDeviceToDevice);
+            }
+         }
+      }
+
+      // Process solvent species
+      if (nSolvent() > 0) {
+
+         // Write each solvent's r-grid data to blockCFields
+         for (i = 0; i < nSolvent(); ++i) {
+            sectionId++;
+
+            UTIL_CHECK(sectionId >= 0);
+            UTIL_CHECK(sectionId < np);
+            UTIL_CHECK(blockCFields[sectionId].capacity() == nx);
+
+            const cudaReal* solventField = solvent(i).cField();
+            cudaMemcpy(blockCFields[sectionID].cDField(), blockField, 
+                       mesh().size() * sizeof(cudaReal), cudaMemcpyDeviceToDevice);
+         }
+      }
+   }
+
 } // namespace Pspg
 } // namespace Pscf
 #endif

--- a/src/pspg/solvers/WaveList.h
+++ b/src/pspg/solvers/WaveList.h
@@ -44,8 +44,8 @@ namespace Pspg
       // into local data structures and implement the actual calculation
       // of kSq or dKSq for each wavevector on the GPU. 
       
-      void computeKSq(UnitCell<D>& unitCell);
-      void computedKSq(UnitCell<D>& unitCell);
+      void computeKSq(const UnitCell<D>& unitCell);
+      void computedKSq(const UnitCell<D>& unitCell);
 
       // Accessors: Return pointer to arrays, which are allocated in 
       // the allocate function(). I assume this is the form needed

--- a/src/pspg/solvers/WaveList.tpp
+++ b/src/pspg/solvers/WaveList.tpp
@@ -217,12 +217,12 @@ namespace Pspg
    }
 
    template <int D>
-   void WaveList<D>::computeKSq(UnitCell<D>& unitCell){
+   void WaveList<D>::computeKSq(const UnitCell<D>& unitCell){
       //pass for now
    }
 
    template <int D>
-   void WaveList<D>::computedKSq(UnitCell<D>& unitCell){
+   void WaveList<D>::computedKSq(const UnitCell<D>& unitCell){
       //dkkbasis is something determined from unit cell size
       //min image needs to be on device but okay since its only done once
       //second to last parameter is number of stars originally


### PR DESCRIPTION
This pull request adds the ability to write an r-grid file that contains a separate column for each block and solvent in the system, even if they are the same monomer type. In fd1d, this already existed and was called WRITE_BLOCK_C, but did not include solvents, so it was modified to include solvents. In pspc and pspg, this functionality did not exist, so a new command WRITE_C_BLOCK_RGRID was added as an option. The code compiles and runs successfully, having been tested for fd1d, pspc, and pspg separately.

To implement this command, a new member function was added to System class called writeBlockCRGrid. I wanted this function to be const because it does not modify the System, which required some significant tweaks to the usage of const in other files, especially in pspg where our usage of const is not nearly as thorough/consistent as it is in pspc. When I was modifying our usage of const in pspg, I tried to mimic the usage in pspc as much as possible. I only modified the usage of const in places that were necessary in order for the code to compile and run with writeBlockCRGrid as a const function.

Here is a brief summary of how it is implemented: the writeBlockCRGrid function allocates a DArray<CField> object, as well as the CField objects it contains, and then passes this DArray<CField> into Mixture::createBlockCRGrid which fills the allocated CField objects with the data for each block and solvent. This DArray<CField> is then passed into the existing function FieldIO::writeFieldsRGrid, which required no additional modifications, to write the data to a file. The DArray<CField> is then destroyed once the scope of writeBlockCRGrid is exited.

I also fixed a few typos that I noticed as I was perusing the source code, which are included here as well. The only typo that actually affects the software was changing "iFlag" to "oFlag" in each of the System.tpp files, which allows for the correct usage of the -o flag to specify an output prefix when running the software from the command line (this didn't work before). The rest of the typos that I fixed were related to incorrect indentation, and won't affect the code at all.