### PR TITLE
Fix filmIterator to work delayed basis construction

### DIFF
--- a/examples/pc/films/1D/param
+++ b/examples/pc/films/1D/param
@@ -28,7 +28,7 @@ System{
     groupName      P_1
   }
   AmIteratorFilm{
-    maxItr       1500
+    maxItr       2500
     epsilon      1e-12
     maxHist      50 
     isFlexible   0

--- a/src/pspc/iterator/FilmIteratorBase.h
+++ b/src/pspc/iterator/FilmIteratorBase.h
@@ -258,6 +258,9 @@ namespace Pspc
 
       /// Wall chiTop array associated with the current system().h() field
       DArray<double> chiTopCurrent_;
+
+      /// Flag indicating whether the wall fields are currently ungenerated
+      bool ungenerated_;
    };
 
    // Inline member functions


### PR DESCRIPTION
FilmIterator now works with the delayed basis construction. This mostly involved rearranging the calls to setup(), generateWallFields(), and setFlexibleParams() to occur at appropriate times. Unit tests are all fixed as well; all this really required was to manually input lattice parameters when needed, since the lattice parameters were no longer being provided from the param file. 

The FilmIteratorBase::setup() function no longer generates the mask and external fields; this is because we need to have lattice parameters accessible in order to correctly generate these fields, and I am leaving us the option to call setup() before we have lattice parameters (although that isn't the case currently). Instead, the mask and external fields are now generated at the beginning of the solve() function. 

All unit tests now pass. I ran the thin film examples and everything looked like it was functioning properly. 