### PR TITLE
NanException, plus some new small fixes and features

### DIFF
--- a/docs/manual/user/command_pc.dox
+++ b/docs/manual/user/command_pc.dox
@@ -275,10 +275,11 @@ command or a group of closely related commands.
   </tr>
   <tr> 
     <td> CHECK_RGRID_SYMMETRY </td>
-    <td> inFile [string] </td>
+    <td> inFile [string], epsilon [double] </td>
     <td> Read fields from file inFile in real-space (r-grid) format,
          check whether the fields are invariant under all elements of
-         the space group specified in the param file.  </td>
+         the space group specified in the param file to within the
+         error threshold epsilon.  </td>
   </tr>
   <tr> 
     <td colspan="3" style="text-align:center"> 

--- a/docs/manual/user/param_sweep.dox
+++ b/docs/manual/user/param_sweep.dox
@@ -172,11 +172,15 @@ The parameter file format for a LinearSweep is summarized below:
        baseFileName      string
        historyCapacity*  int
        reuseState*       bool
+       writeCRGrid*      bool
+       writeCBasis*      bool
+       writeWRGrid*      bool
        nParameter        int
        parameters        Array [ SweepParameter ]
   }
 \endcode
-The purpose of the parameters in this block are explained below:
+Parameters marked with an asterisk are optional. The purpose of the 
+parameters in this block are explained below:
 <table>
   <tr>
     <td> <b> Label </b>  </td>
@@ -206,6 +210,28 @@ The purpose of the parameters in this block are explained below:
     response to perturbations acquired during iteration at the
     previoius state within a sweep, or 0 (false) to always restart 
     the history.  Optional, and true default. </td>
+  </tr>
+  <tr>
+    <td> writeCRGrid* </td>
+    <td> 
+    boolean, set to 1 (true) to write the concentration fields in r-grid
+    format at each step of the sweep, or set to 0 (false) to do nothing. 
+    Optional, and false by default. Not relevant for pscf_fd. </td>
+  </tr>
+  <tr>
+    <td> writeCBasis* </td>
+    <td> 
+    boolean, set to 1 (true) to write the concentration fields in 
+    symmetry-adapted basis format at each step of the sweep, or set to 0
+    (false) to do nothing. Optional, and false by default. Not relevant
+    for pscf_fd. </td>
+  </tr>
+  <tr>
+    <td> writeWRGrid* </td>
+    <td> 
+    boolean, set to 1 (true) to write the potential fields in r-grid
+    format at each step of the sweep, or set to 0 (false) to do nothing. 
+    Optional, and false by default. Not relevant for pscf_fd. </td>
   </tr>
   <tr>
     <td> nParameter </td>

--- a/docs/manual/user/param_sweep.dox
+++ b/docs/manual/user/param_sweep.dox
@@ -172,15 +172,17 @@ The parameter file format for a LinearSweep is summarized below:
        baseFileName      string
        historyCapacity*  int
        reuseState*       bool
-       writeCRGrid*      bool
-       writeCBasis*      bool
-       writeWRGrid*      bool
+       writeCRGrid*+     bool
+       writeCBasis*+     bool
+       writeWRGrid*+     bool
        nParameter        int
        parameters        Array [ SweepParameter ]
   }
 \endcode
-Parameters marked with an asterisk are optional. The purpose of the 
-parameters in this block are explained below:
+Parameters marked with an asterisk are optional. Parameters marked
+with a plus sign are only relevant to pscf_pc and pscf_pg, and cannot
+be used in pscf_fd. The purpose of the parameters in this block are 
+explained below:
 <table>
   <tr>
     <td> <b> Label </b>  </td>

--- a/docs/manual/user/thin_films.dox
+++ b/docs/manual/user/thin_films.dox
@@ -122,6 +122,7 @@ System{
    LinearSweep{
       ns            20  
       baseFileName  out/
+      reuseState    0
       nParameter    3
       parameters[
                     cell_param  1  1.0
@@ -268,6 +269,14 @@ parameter from 4.3 to 5.3, and we sweep `chiBottom[1]` and `chiTop[1]` from
 identical, because asymmetric walls would break the symmetry of the space 
 group that we've chosen, so we'd need to switch to a different space group 
 to model bcc with asymmetric walls.
+
+Finally, notice that there is an additional line in the Sweep block: 
+`reuseState 0`. The reuseState feature typically improves convergence time
+for sweeps by using the last few iterations of the previous sweep step as
+the initial "histories" for the current sweep step. However, this feature 
+actually worsens convergence time when paired with a thin film thickness 
+(`cell_param`) sweep, and thus we include `reuseState 0` in the param file 
+to turn off the feature when sweeping film thickness.
 
 ## The effect of the parameter t
 

--- a/docs/manual/user/thin_films.dox
+++ b/docs/manual/user/thin_films.dox
@@ -321,6 +321,28 @@ parameters are actually allowed to vary based on `normalVecId` and
 with the rules above (*e.g.,* a 2D unit cell with <i>&alpha;</i> &ne; 
 90&deg;), the software will throw an error.
 
+## A Note About The COMPUTE Command
+
+When using PSCF for bulk systems (those without a thin film constraint), 
+users can use the COMPUTE command in the command file to solve the MDEs
+and determine the concentration fields from a given set of potential (w) 
+fields. Based on the way the thin film code is implemented, the COMPUTE
+command will currently give the wrong result if the system in question 
+has a thin film constraint. This is because the code has to generate 
+external fields and a mask field to represent the upper and lower walls,
+which alter the other calculations that happen within the system, and these
+fields are not generated until the ITERATE command is called. 
+
+If the user wishes to simply solve the MDEs for a thin film system without 
+iterating to a solution, we recommend the following workaround: instead of
+calling COMPUTE, set the epsilon value of the iterator to a very large 
+number (say, 1e5) and call ITERATE. The MDE solution at Iteration 0 will 
+be "converged" because it will have an error value that is lower than 
+epsilon, and so the iteration procedure will terminate on Iteration 0 
+without ever updating the potential fields. Thus, the only operation 
+performed by ITERATE will be solving the MDEs, which will then allow the
+user to write the resulting concentration fields to a file.
+
 #  Space Groups
 
 Although we are imposing a thin film constraint on the system, we still use 

--- a/examples/pc/films/1D/command
+++ b/examples/pc/films/1D/command
@@ -1,14 +1,13 @@
-RGRID_TO_KGRID   in/c.rf   in/c.kf
-RGRID_TO_BASIS   in/c.rf   in/c.bf
-GUESS_W_FROM_C   in/c.bf   in/w.bf
-READ_W_BASIS     in/w.bf
+RGRID_TO_KGRID     in/c.rf   in/c.kf
+RGRID_TO_BASIS     in/c.rf   in/c.bf
+ESTIMATE_W_FROM_C  in/c.bf   in/w.bf
 ITERATE          
-WRITE_W_BASIS    out/w.bf
-WRITE_C_BASIS    out/c.bf
-WRITE_C_RGRID    out/c.rf
-WRITE_MASK_RGRID out/mask.rf
-WRITE_H_RGRID    out/h.rf
-WRITE_PARAM      out/data
-WRITE_THERMO     out/data
+WRITE_W_BASIS      out/w.bf
+WRITE_C_BASIS      out/c.bf
+WRITE_C_RGRID      out/c.rf
+WRITE_MASK_RGRID   out/mask.rf
+WRITE_H_RGRID      out/h.rf
+WRITE_PARAM        out/data
+WRITE_THERMO       out/data
 FINISH
 

--- a/examples/pc/films/2D/command
+++ b/examples/pc/films/2D/command
@@ -1,14 +1,13 @@
-RGRID_TO_KGRID   in/c.rf   in/c.kf
-RGRID_TO_BASIS   in/c.rf   in/c.bf
-GUESS_W_FROM_C   in/c.bf   in/w.bf
-READ_W_BASIS     in/w.bf
-WRITE_W_RGRID    in/w.rf
+RGRID_TO_KGRID     in/c.rf   in/c.kf
+RGRID_TO_BASIS     in/c.rf   in/c.bf
+ESTIMATE_W_FROM_C  in/c.bf   in/w.bf
+WRITE_W_RGRID      in/w.rf
 ITERATE
-WRITE_W_BASIS    out/w.bf
-WRITE_C_RGRID    out/c.rf
-WRITE_MASK_RGRID out/mask.rf
-WRITE_H_RGRID    out/h.rf
-WRITE_PARAM      out/data
-WRITE_THERMO     out/data
+WRITE_W_BASIS      out/w.bf
+WRITE_C_RGRID      out/c.rf
+WRITE_MASK_RGRID   out/mask.rf
+WRITE_H_RGRID      out/h.rf
+WRITE_PARAM        out/data
+WRITE_THERMO       out/data
 FINISH
 

--- a/examples/pc/films/3D/command
+++ b/examples/pc/films/3D/command
@@ -1,15 +1,14 @@
-RGRID_TO_KGRID   in/c.rf   in/c.kf
-RGRID_TO_BASIS   in/c.rf   in/c.bf
-GUESS_W_FROM_C   in/c.bf   in/w.bf
-READ_W_BASIS     in/w.bf
-WRITE_W_RGRID    in/w.rf
+RGRID_TO_KGRID     in/c.rf   in/c.kf
+RGRID_TO_BASIS     in/c.rf   in/c.bf
+ESTIMATE_W_FROM_C  in/c.bf   in/w.bf
+WRITE_W_RGRID      in/w.rf
 ITERATE    
-WRITE_W_BASIS    out/w.bf
-WRITE_W_RGRID    out/w.rf
-WRITE_C_BASIS    out/c.bf
-WRITE_C_RGRID    out/c.rf
-WRITE_MASK_RGRID out/mask.rf
-WRITE_PARAM      out/data
-WRITE_THERMO     out/data
+WRITE_W_BASIS      out/w.bf
+WRITE_W_RGRID      out/w.rf
+WRITE_C_BASIS      out/c.bf
+WRITE_C_RGRID      out/c.rf
+WRITE_MASK_RGRID   out/mask.rf
+WRITE_PARAM        out/data
+WRITE_THERMO       out/data
 FINISH
 

--- a/examples/pc/films/chi_bottom_sweep/command
+++ b/examples/pc/films/chi_bottom_sweep/command
@@ -1,7 +1,6 @@
-RGRID_TO_KGRID   in/c.rf   in/c.kf
-RGRID_TO_BASIS   in/c.rf   in/c.bf
-GUESS_W_FROM_C   in/c.bf   in/w.bf
-READ_W_BASIS     in/w.bf
+RGRID_TO_KGRID     in/c.rf   in/c.kf
+RGRID_TO_BASIS     in/c.rf   in/c.bf
+ESTIMATE_W_FROM_C  in/c.bf   in/w.bf
 SWEEP
 FINISH
 

--- a/examples/pc/films/chi_bottom_sweep/param
+++ b/examples/pc/films/chi_bottom_sweep/param
@@ -39,7 +39,7 @@ System{
   LinearSweep{
     ns            40
     baseFileName  out/
-    writeRhoRGrid 1
+    writeCRGrid   1
     nParameter    1
     parameters[
                   chi_bottom  0  +20.0

--- a/examples/pc/films/thickness_sweep/command
+++ b/examples/pc/films/thickness_sweep/command
@@ -1,7 +1,6 @@
-RGRID_TO_KGRID   in/c.rf   in/c.kf
-RGRID_TO_BASIS   in/c.rf   in/c.bf
-GUESS_W_FROM_C   in/c.bf   in/w.bf
-READ_W_BASIS     in/w.bf
+RGRID_TO_KGRID     in/c.rf   in/c.kf
+RGRID_TO_BASIS     in/c.rf   in/c.bf
+ESTIMATE_W_FROM_C  in/c.bf   in/w.bf
 SWEEP          
 FINISH
 

--- a/examples/pc/films/thickness_sweep/param
+++ b/examples/pc/films/thickness_sweep/param
@@ -41,6 +41,7 @@ System{
   LinearSweep{
     ns            20  
     baseFileName  out/
+    reuseState    0
     writeRhoRGrid 1
     nParameter    1   
     parameters[

--- a/examples/pc/films/thickness_sweep/param
+++ b/examples/pc/films/thickness_sweep/param
@@ -42,7 +42,7 @@ System{
     ns            20  
     baseFileName  out/
     reuseState    0
-    writeRhoRGrid 1
+    writeCRGrid   1
     nParameter    1   
     parameters[
                   cell_param  0  0.5

--- a/examples/pc/sweep/block/param
+++ b/examples/pc/sweep/block/param
@@ -34,6 +34,9 @@ System{
   LinearSweep{
     ns            4
     baseFileName  out/
+    writeCRGrid   1
+    writeCBasis   1
+    writeWRGrid   1
     nParameter    2
     parameters[
            block  0 0 +0.08

--- a/src/fd1d/iterator/AmIterator.cpp
+++ b/src/fd1d/iterator/AmIterator.cpp
@@ -8,6 +8,7 @@
 #include "AmIterator.h"
 #include <fd1d/System.h>
 #include <pscf/inter/Interaction.h>
+#include <pscf/iterator/NanException.h>
 #include <util/global.h>
 
 namespace Pscf {
@@ -55,6 +56,10 @@ namespace Fd1d{
       UTIL_CHECK(n == b.capacity());
       double product = 0.0;
       for (int i = 0; i < n; i++) {
+         // if either value is NaN, throw NanException
+         if (std::isnan(a[i]) || std::isnan(b[i])) { 
+            throw NanException("AmIterator::dotProduct",__FILE__,__LINE__,0);
+         }
          product += a[i] * b[i];
       }
       return product;
@@ -65,9 +70,14 @@ namespace Fd1d{
    {
       const int n = hist.capacity();
       double maxRes = 0.0;
+      double value;
       for (int i = 0; i < n; i++) {
-         if (fabs(hist[i]) > maxRes)
-            maxRes = fabs(hist[i]);
+         value = hist[i];
+         if (std::isnan(value)) { // if value is NaN, throw NanException
+            throw NanException("AmIterator::dotProduct",__FILE__,__LINE__,0);
+         }
+         if (fabs(value) > maxRes)
+            maxRes = fabs(value);
       }
       return maxRes;
    }

--- a/src/pscf/iterator/AmIteratorTmpl.tpp
+++ b/src/pscf/iterator/AmIteratorTmpl.tpp
@@ -142,7 +142,7 @@ namespace Pscf
          timerError.start();
          double error = computeError(verbose_);
          if (verbose_ < 2) {
-             Log::file() << ",  error  = " << Dbl(error, 15) << "\n";
+             Log::file() << ",  error  = " << Dbl(error, 15) << std::endl;
          }
          timerError.stop();
 
@@ -490,7 +490,7 @@ namespace Pscf
          // Find norm of residual vector relative to field
          double normField = norm(fieldHists_[0]);
          double relNormRes = normRes/normField;
-         Log::file() << "Relative Norm = " << Dbl(relNormRes,15) << "\n";
+         Log::file() << "Relative Norm = " << Dbl(relNormRes,15) << std::endl;
    
          // Check if calculation has diverged (normRes will be NaN)
          UTIL_CHECK(!std::isnan(normRes));

--- a/src/pscf/iterator/AmIteratorTmpl.tpp
+++ b/src/pscf/iterator/AmIteratorTmpl.tpp
@@ -10,6 +10,7 @@
 
 #include <pscf/inter/Interaction.h>
 #include <pscf/math/LuSolver.h>
+#include "NanException.h"
 #include <util/containers/FArray.h>
 #include <util/format/Dbl.h>
 #include <util/format/Int.h>
@@ -140,7 +141,13 @@ namespace Pscf
 
          // Compute scalar error, output report to log file.
          timerError.start();
-         double error = computeError(verbose_);
+         double error;
+         try {
+            error = computeError(verbose_);
+         } catch (const NanException&) {
+            Log::file() << ",  error  =             NaN" << std::endl;
+            break; // Exit loop if a NanException is caught
+         }
          if (verbose_ < 2) {
              Log::file() << ",  error  = " << Dbl(error, 15) << std::endl;
          }

--- a/src/pscf/iterator/NanException.cpp
+++ b/src/pscf/iterator/NanException.cpp
@@ -1,0 +1,39 @@
+/*
+* PSCF - Polymer Self-Consistent Field Theory
+*
+* Copyright 2016 - 2022, The Regents of the University of Minnesota
+* Distributed under the terms of the GNU General Public License.
+*/
+
+#include "NanException.h"
+#include <sstream>
+
+namespace Pscf
+{
+
+   using namespace Util;
+
+   /*
+   * Constructor, with function name.
+   */
+   NanException::NanException(const char *function, const char *file, 
+                              int line, int echo) 
+    : Exception(function, "required numerical parameter has value of NaN",
+                file, line, echo)
+   {}
+
+   /*
+   * Constructor, with no function name.
+   */
+   NanException::NanException(const char *file, int line, int echo) 
+    : Exception("required numerical parameter has value of NaN",
+                file, line, echo)
+   {}
+
+   /*
+   * Destructor.
+   */
+   NanException::~NanException()
+   {}
+
+}

--- a/src/pscf/iterator/NanException.h
+++ b/src/pscf/iterator/NanException.h
@@ -1,0 +1,74 @@
+#ifndef PSCF_NAN_EXCEPTION_H
+#define PSCF_NAN_EXCEPTION_H
+
+/*
+* PSCF - Polymer Self-Consistent Field Theory
+*
+* Copyright 2016 - 2022, The Regents of the University of Minnesota
+* Distributed under the terms of the GNU General Public License.
+*/
+
+#include <util/global.h>                  
+#include <util/misc/Exception.h>
+
+namespace Pscf {
+
+   using namespace Util;
+
+   /**
+   * An exception to be thrown when a required numerical parameter has a 
+   * value of NaN. This may happen, for instance, as a result of dividing
+   * by zero. A NanException is used rather than a generic Exception in 
+   * these instances so that the NanException can be caught by a try-catch
+   * block.
+   * 
+   * A NanException behaves identically to a generic Exception, but with a
+   * pre-defined error message rather than a user-specified message. There 
+   * is no preprocessor macro to throw a NanException, so they must be thrown
+   * using the constructor. This will typically assume the following syntax,
+   * where values of the file and line parameters are given by the built-in 
+   * macros __FILE__ and __LINE__, respectively:
+   * \code
+   *    throw Exception("MyClass::myFunction", __FILE__, __LINE__ );
+   * \endcode
+   *
+   * \ingroup Pscf_Iterator_Module
+   */
+   class NanException : public Exception
+   {
+
+   public:
+
+      /**
+      * Constructor. 
+      *
+      * Constructs error message that includes file and line number. Values 
+      * of the file and line parameters should be given by the built-in macros
+      * __FILE__ and __LINE__, respectively, in the calling function. 
+      *
+      * \param function name of the function from which the Exception was thrown
+      * \param file     name of the file from which the Exception was thrown
+      * \param line     line number in file
+      * \param echo     if echo, then echo to Log::file() when constructed. 
+      */
+      NanException(const char *function, const char *file, int line, 
+                   int echo = 1);
+
+      /**
+      * Constructor without function name parameter.
+      *
+      * \param file     name of the file from which the Exception was thrown
+      * \param line     line number in file
+      * \param echo     if echo, then echo to std out when constructed. 
+      */
+      NanException(const char *file, int line, int echo = 1);
+
+      /**
+      * Destructor
+      */   
+      ~NanException();
+
+   };
+
+}
+#endif

--- a/src/pscf/iterator/NanException.h
+++ b/src/pscf/iterator/NanException.h
@@ -16,6 +16,8 @@ namespace Pscf {
    using namespace Util;
 
    /**
+   * Exception thrown when not-a-number (NaN) is encountered.
+   * 
    * An exception to be thrown when a required numerical parameter has a 
    * value of NaN. This may happen, for instance, as a result of dividing
    * by zero. A NanException is used rather than a generic Exception in 

--- a/src/pscf/iterator/sources.mk
+++ b/src/pscf/iterator/sources.mk
@@ -1,5 +1,6 @@
 pscf_iterator_= \
-  pscf/iterator/AmbdInteraction.cpp 
+  pscf/iterator/AmbdInteraction.cpp \
+  pscf/iterator/NanException.cpp
 
 pscf_iterator_SRCS=\
      $(addprefix $(SRC_DIR)/, $(pscf_iterator_))

--- a/src/pscf/sweep/SweepTmpl.h
+++ b/src/pscf/sweep/SweepTmpl.h
@@ -52,15 +52,6 @@ namespace Pscf {
       /// Base name for output files
       std::string baseFileName_;
 
-      /// Whether to write real space concentration field files. 
-      bool writeCRGrid_;
-
-      /// Whether to write concentration field files in basis format. 
-      bool writeCBasis_;
-
-      /// Whether to write real space potential field files. 
-      bool writeWRGrid_;
-
       /**
       * Constructor (protected).
       *

--- a/src/pscf/sweep/SweepTmpl.h
+++ b/src/pscf/sweep/SweepTmpl.h
@@ -53,7 +53,13 @@ namespace Pscf {
       std::string baseFileName_;
 
       /// Whether to write real space concentration field files. 
-      bool writeRhoRGrid_;
+      bool writeCRGrid_;
+
+      /// Whether to write concentration field files in basis format. 
+      bool writeCBasis_;
+
+      /// Whether to write real space potential field files. 
+      bool writeWRGrid_;
 
       /**
       * Constructor (protected).

--- a/src/pscf/sweep/SweepTmpl.tpp
+++ b/src/pscf/sweep/SweepTmpl.tpp
@@ -118,6 +118,8 @@ namespace Pscf {
 
             // Process success or failure
             if (error) {
+               Log::file() << "Backtrack and halve sweep step size:" 
+                           << std::endl;
 
                // Upon failure, reset state to last converged solution
                reset();

--- a/src/pscf/sweep/SweepTmpl.tpp
+++ b/src/pscf/sweep/SweepTmpl.tpp
@@ -22,7 +22,9 @@ namespace Pscf {
    SweepTmpl<State>::SweepTmpl(int historyCapacity)
     : ns_(0),
       baseFileName_(),
-      writeRhoRGrid_(false),
+      writeCRGrid_(false),
+      writeCBasis_(false),
+      writeWRGrid_(false),
       historyCapacity_(historyCapacity),
       historySize_(0),
       nAccept_(0),
@@ -50,7 +52,9 @@ namespace Pscf {
       readOptional<std::string>(in, "baseFileName", baseFileName_);
       readOptional<int>(in, "historyCapacity", historyCapacity_);
       readOptional<bool>(in, "reuseState", reuseState_);
-      readOptional<bool>(in, "writeRhoRGrid", writeRhoRGrid_);
+      readOptional<bool>(in, "writeCRGrid", writeCRGrid_);
+      readOptional<bool>(in, "writeCBasis", writeCBasis_);
+      readOptional<bool>(in, "writeWRGrid", writeWRGrid_);
 
       // Allocate required arrays
       UTIL_CHECK(historyCapacity_ > 0);

--- a/src/pscf/sweep/SweepTmpl.tpp
+++ b/src/pscf/sweep/SweepTmpl.tpp
@@ -22,9 +22,6 @@ namespace Pscf {
    SweepTmpl<State>::SweepTmpl(int historyCapacity)
     : ns_(0),
       baseFileName_(),
-      writeCRGrid_(false),
-      writeCBasis_(false),
-      writeWRGrid_(false),
       historyCapacity_(historyCapacity),
       historySize_(0),
       nAccept_(0),
@@ -52,9 +49,6 @@ namespace Pscf {
       readOptional<std::string>(in, "baseFileName", baseFileName_);
       readOptional<int>(in, "historyCapacity", historyCapacity_);
       readOptional<bool>(in, "reuseState", reuseState_);
-      readOptional<bool>(in, "writeCRGrid", writeCRGrid_);
-      readOptional<bool>(in, "writeCBasis", writeCBasis_);
-      readOptional<bool>(in, "writeWRGrid", writeWRGrid_);
 
       // Allocate required arrays
       UTIL_CHECK(historyCapacity_ > 0);

--- a/src/pspc/System.h
+++ b/src/pspc/System.h
@@ -531,9 +531,13 @@ namespace Pspc
       * Check if r-grid fields have the declared space group symmetry.
       *
       * \param inFileName name of input file
+      * \param epsilon error threshold used when comparing the k-grid and 
+      * symmetry-adapted formats to determine whether field has the declared 
+      * space group symmetry
       * \return true if fields all have symmetry, false otherwise
       */
-      bool checkRGridFieldSymmetry(const std::string & inFileName);
+      bool checkRGridFieldSymmetry(const std::string & inFileName,
+                                   double epsilon);
 
       //@}
       /// \name Member Accessors

--- a/src/pspc/System.tpp
+++ b/src/pspc/System.tpp
@@ -1071,6 +1071,11 @@ namespace Pspc
          out << std::endl;
       }
 
+      out << "Lattice parameters:" << std::endl << "     ";
+      for (int i = 0; i < unitCell().nParameter(); ++i) {
+         out << "  " << Dbl(unitCell().parameter(i), 18, 11);
+      }
+      out << std::endl << std::endl;
    }
 
    /*

--- a/src/pspc/System.tpp
+++ b/src/pspc/System.tpp
@@ -624,18 +624,25 @@ namespace Pspc
          } else
          if (command == "CHECK_RGRID_SYMMETRY") {
             readEcho(in, inFileName);
+            double epsilon;
+            in >> epsilon;
+            if (in.fail()) {
+               UTIL_THROW("Unable to read numerical parameter epsilon.");
+            }
+            Log::file() << " " << Dbl(epsilon, 20) << std::endl;
             bool hasSymmetry;
-            hasSymmetry = checkRGridFieldSymmetry(inFileName);
+            hasSymmetry = checkRGridFieldSymmetry(inFileName, epsilon);
             if (hasSymmetry) {
-               Log::file() 
+               Log::file() << std::endl
                    << "Symmetry of r-grid file matches this space group." 
-                   << std::endl;
+                   << std::endl << std::endl;
             } else {
-               Log::file() 
+               Log::file() << std::endl
                    << "Symmetry of r-grid file does not match this space group" 
                    << std::endl
-                   << "to within our error threshold of 1E-8."
-                   << std::endl;
+                   << "to within error threshold of "
+                   << Dbl(epsilon) << "."
+                   << std::endl << std::endl;
             }
          } else
          if (command == "COMPARE_BASIS") {
@@ -822,7 +829,7 @@ namespace Pspc
          mixture_.computeStress();
       }
 
-      // If w fields are symmetric, compute basis componens for c-fields
+      // If w fields are symmetric, compute basis components for c-fields
       if (w_.isSymmetric()) {
          UTIL_CHECK(c_.isAllocatedBasis());
          domain_.fieldIo().convertRGridToBasis(c_.rgrid(), c_.basis());
@@ -1528,7 +1535,8 @@ namespace Pspc
    * Convert fields from real-space grid to symmetry-adapted basis format.
    */
    template <int D>
-   bool System<D>::checkRGridFieldSymmetry(const std::string & inFileName) 
+   bool System<D>::checkRGridFieldSymmetry(const std::string & inFileName,
+                                           double epsilon) 
    {
       // If basis fields are not allocated, peek at field file header to 
       // get unit cell parameters, initialize basis and allocate fields.
@@ -1545,7 +1553,8 @@ namespace Pspc
       // Check symmetry for all fields
       for (int i = 0; i < mixture_.nMonomer(); ++i) {
          bool symmetric;
-         symmetric = domain_.fieldIo().hasSymmetry(tmpFieldsRGrid_[i]);
+         symmetric = domain_.fieldIo().hasSymmetry(tmpFieldsRGrid_[i],
+                                                   epsilon);
          if (!symmetric) {
             return false;
          }

--- a/src/pspc/System.tpp
+++ b/src/pspc/System.tpp
@@ -832,7 +832,7 @@ namespace Pspc
       // If w fields are symmetric, compute basis components for c-fields
       if (w_.isSymmetric()) {
          UTIL_CHECK(c_.isAllocatedBasis());
-         domain_.fieldIo().convertRGridToBasis(c_.rgrid(), c_.basis());
+         domain_.fieldIo().convertRGridToBasis(c_.rgrid(), c_.basis(), false);
       }
 
    }

--- a/src/pspc/field/FieldIo.h
+++ b/src/pspc/field/FieldIo.h
@@ -459,9 +459,17 @@ namespace Pspc
       *
       * \param in  complex DFT (k-grid) representation of a field.
       * \param out  coefficients of symmetry-adapted basis functions.
+      * \param checkSymmetry  boolean indicating whether to check that the 
+      * symmetry of the input field matches the space group symmetry. If
+      * input does not have correct symmetry, prints warning to Log::file().
+      * \param epsilon  if checkSymmetry = true, epsilon is the error 
+      * threshold used when comparing the k-grid and symmetry-adapted formats 
+      * to determine whether field has the declared space group symmetry.
       */
       void convertKGridToBasis(RFieldDft<D> const & in, 
-                               DArray<double> & out) const;
+                               DArray<double> & out,
+                               bool checkSymmetry = true,
+                               double epsilon = 1.0e-8) const;
 
       /**
       * Convert fields from Fourier transform (kgrid) to symmetrized basis.
@@ -471,9 +479,17 @@ namespace Pspc
       *
       * \param in  fields defined as discrete Fourier transforms (k-grid)
       * \param out  components of fields in symmetry adapted basis 
+      * \param checkSymmetry  boolean indicating whether to check that the 
+      * symmetry of the input field matches the space group symmetry. If
+      * input does not have correct symmetry, prints warning to Log::file().
+      * \param epsilon  if checkSymmetry = true, epsilon is the error 
+      * threshold used when comparing the k-grid and symmetry-adapted formats 
+      * to determine whether field has the declared space group symmetry.
       */
       void convertKGridToBasis(DArray< RFieldDft<D> > const & in,
-                               DArray< DArray<double> > & out) const;
+                               DArray< DArray<double> > & out,
+                               bool checkSymmetry = true,
+                               double epsilon = 1.0e-8) const;
 
       /**
       * Convert a field from symmetrized basis to spatial grid (r-grid).
@@ -498,18 +514,34 @@ namespace Pspc
       * 
       * \param in  field defined on real-space grid
       * \param out  field in symmetry adapted basis form
+      * \param checkSymmetry  boolean indicating whether to check that the 
+      * symmetry of the input field matches the space group symmetry. If
+      * input does not have correct symmetry, prints warning to Log::file()
+      * \param epsilon  if checkSymmetry = true, epsilon is the error 
+      * threshold used when comparing the k-grid and symmetry-adapted formats 
+      * to determine whether field has the declared space group symmetry
       */
       void convertRGridToBasis(RField<D> const & in,
-                               DArray<double> & out) const;
+                               DArray<double> & out,
+                               bool checkSymmetry = true, 
+                               double epsilon = 1.0e-8) const;
 
       /**
       * Convert fields from spatial grid (r-grid) to symmetrized basis.
       * 
       * \param in  fields defined on real-space grid
       * \param out  fields in symmetry adapted basis form
+      * \param checkSymmetry  boolean indicating whether to check that the 
+      * symmetry of the input field matches the space group symmetry. If
+      * input does not have correct symmetry, prints warning to Log::file()
+      * \param epsilon  if checkSymmetry = true, epsilon is the error 
+      * threshold used when comparing the k-grid and symmetry-adapted formats 
+      * to determine whether field has the declared space group symmetry
       */
       void convertRGridToBasis(DArray< RField<D> > const & in,
-                               DArray< DArray<double> > & out) const;
+                               DArray< DArray<double> > & out,
+                               bool checkSymmetry = true, 
+                               double epsilon = 1.0e-8) const;
 
       /**
       * Convert fields from k-grid (DFT) to real space (r-grid) format.
@@ -563,21 +595,29 @@ namespace Pspc
       * Check if an r-grid field has the declared space group symmetry.
       *
       * \param in field in real space grid (r-grid) format
+      * \param epsilon error threshold used when comparing the k-grid and
+      * symmetry-adapted formats to determine whether field has the declared
+      * space group symmetry.
       * \param verbose if field does not have symmetry and verbose = true,
       * function will write error values to Log::file().
       * \return true if the field is symmetric, false otherwise
       */
-      bool hasSymmetry(RField<D> const & in, bool verbose = true) const;
+      bool hasSymmetry(RField<D> const & in, double epsilon = 1.0e-8,
+                       bool verbose = true) const;
 
       /**
       * Check if a k-grid field has declared space group symmetry.
       *
       * \param in field in real space grid (r-grid) format
+      * \param epsilon error threshold used when comparing the k-grid and
+      * symmetry-adapted formats to determine whether field has the declared
+      * space group symmetry.
       * \param verbose if field does not have symmetry and verbose = true,
       * function will write error values to Log::file().
       * \return true if the field is symmetric, false otherwise
       */
-      bool hasSymmetry(RFieldDft<D> const & in, bool verbose = true) const;
+      bool hasSymmetry(RFieldDft<D> const & in, double epsilon = 1.0e-8,
+                       bool verbose = true) const;
 
       ///@}
 

--- a/src/pspc/field/FieldIo.tpp
+++ b/src/pspc/field/FieldIo.tpp
@@ -1195,9 +1195,30 @@ namespace Pspc
 
    template <int D>
    void FieldIo<D>::convertKGridToBasis(RFieldDft<D> const & in, 
-                                        DArray<double>& out) const
+                                        DArray<double>& out,
+                                        bool checkSymmetry, double epsilon) 
+                                        const
    {
       UTIL_CHECK(basis().isInitialized());
+
+      if (checkSymmetry) {
+         // Check if kgrid has symmetry
+         bool symmetric = hasSymmetry(in, epsilon, true);
+         if (!symmetric) {
+            Log::file() << std::endl
+                        << "WARNING: non-negligible error in conversion to "
+                        << "symmetry-adapted basis format." 
+                        << std::endl
+                        << "   See error values printed above for each "
+                        << "asymmetric field."
+                        << std::endl
+                        << "   The field that is output by the above operation "
+                        << "will be a"
+                        << std::endl
+                        << "   symmetrized version of the input field."
+                        << std::endl << std::endl;
+         }
+      }
 
       // Create Mesh<D> with dimensions of DFT Fourier grid.
       Mesh<D> dftMesh(in.dftDimensions());
@@ -1306,18 +1327,21 @@ namespace Pspc
 
    template <int D>
    void FieldIo<D>::convertKGridToBasis(DArray< RFieldDft<D> > const & in,
-                                        DArray< DArray <double> > & out) const
+                                        DArray< DArray <double> > & out,
+                                        bool checkSymmetry, double epsilon) 
+                                        const
    {
       UTIL_ASSERT(in.capacity() == out.capacity());
       int n = in.capacity();
       bool symmetric(true);
 
       for (int i = 0; i < n; ++i) {
-         // Check if kgrid has symmetry
-         bool tmp_sym = hasSymmetry(in[i], true);
-         if (!tmp_sym) symmetric = false;
-
-         convertKGridToBasis(in[i], out[i]);
+         if (checkSymmetry) {
+            // Check if kgrid has symmetry
+            bool tmp_sym = hasSymmetry(in[i], epsilon, true);
+            if (!tmp_sym) symmetric = false;
+         }
+         convertKGridToBasis(in[i], out[i], false);
       }
 
       // Print warning if any input fields didn't meet symmetry of space group
@@ -1365,17 +1389,19 @@ namespace Pspc
    template <int D>
    void 
    FieldIo<D>::convertRGridToBasis(RField<D> const & in,
-                                   DArray<double> & out) const
+                                   DArray<double> & out,
+                                   bool checkSymmetry, double epsilon) const
    {
       checkWorkDft();
       fft().forwardTransform(in, workDft_);
-      convertKGridToBasis(workDft_, out);
+      convertKGridToBasis(workDft_, out, checkSymmetry, epsilon);
    }
 
    template <int D>
    void 
    FieldIo<D>::convertRGridToBasis(DArray< RField<D> > const & in,
-                                   DArray< DArray <double> > & out) const
+                                   DArray< DArray <double> > & out,
+                                   bool checkSymmetry, double epsilon) const
    {
       UTIL_ASSERT(in.capacity() == out.capacity());
       checkWorkDft();
@@ -1385,12 +1411,12 @@ namespace Pspc
 
       for (int i = 0; i < n; ++i) {
          fft().forwardTransform(in[i], workDft_);
-
-         // Check if kgrid has symmetry
-         bool tmp_sym = hasSymmetry(workDft_, true);
-         if (!tmp_sym) symmetric = false;
-
-         convertKGridToBasis(workDft_, out[i]);
+         if (checkSymmetry) {
+            // Check if kgrid has symmetry
+            bool tmp_sym = hasSymmetry(workDft_, epsilon, true);
+            if (!tmp_sym) symmetric = false;
+         }
+         convertKGridToBasis(workDft_, out[i], false);
       }
 
       // Print warning if any input fields didn't meet symmetry of space group
@@ -1455,10 +1481,12 @@ namespace Pspc
    * if verbose == true and hasSymmetry == false.
    */
    template <int D>
-   bool FieldIo<D>::hasSymmetry(RField<D> const & in, bool verbose) const
+   bool FieldIo<D>::hasSymmetry(RField<D> const & in, double epsilon,
+                                bool verbose) const
    {
+      checkWorkDft();
       fft().forwardTransform(in, workDft_);
-      return hasSymmetry(workDft_, verbose);
+      return hasSymmetry(workDft_, epsilon, verbose);
    }
 
    /*
@@ -1467,7 +1495,8 @@ namespace Pspc
    * if verbose == true and hasSymmetry == false.
    */
    template <int D>
-   bool FieldIo<D>::hasSymmetry(RFieldDft<D> const & in, bool verbose) const
+   bool FieldIo<D>::hasSymmetry(RFieldDft<D> const & in, double epsilon,
+                                bool verbose) const
    {
       UTIL_CHECK(basis().isInitialized());
 
@@ -1503,7 +1532,9 @@ namespace Pspc
                   waveCoeff = std::complex<double>(in[rank][0], in[rank][1]);
                   if (std::abs(waveCoeff) > cancelledError) {
                      cancelledError = std::abs(waveCoeff);
-                     if ((!verbose) && (cancelledError > 1e-8)) return false;
+                     if ((!verbose) && (cancelledError > epsilon)) {
+                        return false;
+                     }
                   }
                }
             }
@@ -1524,7 +1555,7 @@ namespace Pspc
                      diff = waveCoeff - rootCoeff;
                      if (std::abs(diff) > uncancelledError) {
                         uncancelledError = std::abs(diff);
-                        if ((!verbose) && (uncancelledError > 1e-8)) {
+                        if ((!verbose) && (uncancelledError > epsilon)) {
                            return false;
                         }
                      }
@@ -1539,7 +1570,7 @@ namespace Pspc
 
       } //  end loop over star index is
 
-      if ((cancelledError < 1e-8) && (uncancelledError < 1e-8)) {
+      if ((cancelledError < epsilon) && (uncancelledError < epsilon)) {
          return true;
       } else if (verbose) {
          Log::file() << std::endl

--- a/src/pspc/iterator/AmIterator.tpp
+++ b/src/pspc/iterator/AmIterator.tpp
@@ -11,6 +11,7 @@
 #include "AmIterator.h"
 #include <pspc/System.h>
 #include <pscf/inter/Interaction.h>
+#include <pscf/iterator/NanException.h>
 #include <util/global.h>
 #include <cmath>
 
@@ -98,11 +99,12 @@ namespace Pspc{
    {
       const int n = a.capacity();
       UTIL_CHECK(b.capacity() == n);
-      double value;
       double product = 0.0;
       for (int i = 0; i < n; i++) {
-         value = a[i];
-         UTIL_CHECK(!std::isnan(value));
+         // if either value is NaN, throw NanException
+         if (std::isnan(a[i]) || std::isnan(b[i])) { 
+            throw NanException("AmIterator::dotProduct",__FILE__,__LINE__,0);
+         }
          product += a[i] * b[i];
       }
       return product;
@@ -117,7 +119,9 @@ namespace Pspc{
       double value;
       for (int i = 0; i < n; i++) {
          value = a[i];
-         UTIL_CHECK(!std::isnan(value));
+         if (std::isnan(value)) { // if value is NaN, throw NanException
+            throw NanException("AmIterator::dotProduct",__FILE__,__LINE__,0);
+         }
          if (fabs(value) > max) {
             max = fabs(value);
          }

--- a/src/pspc/sweep/LinearSweep.tpp
+++ b/src/pspc/sweep/LinearSweep.tpp
@@ -26,7 +26,7 @@ namespace Pspc {
    void LinearSweep<D>::readParameters(std::istream& in)
    {
       // Call the base class's readParameters function.
-      SweepTmpl< BasisFieldState<D> >::readParameters(in);
+      Sweep<D>::readParameters(in);
       
       // Read in the number of sweep parameters and allocate.
       this->read(in, "nParameter", nParameter_);

--- a/src/pspc/sweep/Sweep.h
+++ b/src/pspc/sweep/Sweep.h
@@ -47,6 +47,13 @@ namespace Pspc {
       */
       void setSystem(System<D>& system);
 
+      /**
+      * Read parameters from param file.
+      * 
+      * \param in Input stream from param file.
+      */
+      virtual void readParameters(std::istream& in);
+
       // Public members inherited from base class template SweepTmpl
       using SweepTmpl< BasisFieldState<D> >::historyCapacity;
       using SweepTmpl< BasisFieldState<D> >::historySize;
@@ -124,14 +131,21 @@ namespace Pspc {
       System<D>& system()
       {  return *systemPtr_; }
 
-      // Protected members inherited from base class template SweepTmpl
+      /// Whether to write real space concentration field files. 
+      bool writeCRGrid_;
+
+      /// Whether to write concentration field files in basis format. 
+      bool writeCBasis_;
+
+      /// Whether to write real space potential field files. 
+      bool writeWRGrid_;
+
+      // Protected members inherited from base classes
       using SweepTmpl< BasisFieldState<D> >::ns_;
       using SweepTmpl< BasisFieldState<D> >::baseFileName_;
-      using SweepTmpl< BasisFieldState<D> >::writeCRGrid_;
-      using SweepTmpl< BasisFieldState<D> >::writeCBasis_;
-      using SweepTmpl< BasisFieldState<D> >::writeWRGrid_;
       using SweepTmpl< BasisFieldState<D> >::initialize;
       using SweepTmpl< BasisFieldState<D> >::setCoefficients;
+      using ParamComposite::readOptional;
 
    private:
 

--- a/src/pspc/sweep/Sweep.h
+++ b/src/pspc/sweep/Sweep.h
@@ -127,7 +127,9 @@ namespace Pspc {
       // Protected members inherited from base class template SweepTmpl
       using SweepTmpl< BasisFieldState<D> >::ns_;
       using SweepTmpl< BasisFieldState<D> >::baseFileName_;
-      using SweepTmpl< BasisFieldState<D> >::writeRhoRGrid_;
+      using SweepTmpl< BasisFieldState<D> >::writeCRGrid_;
+      using SweepTmpl< BasisFieldState<D> >::writeCBasis_;
+      using SweepTmpl< BasisFieldState<D> >::writeWRGrid_;
       using SweepTmpl< BasisFieldState<D> >::initialize;
       using SweepTmpl< BasisFieldState<D> >::setCoefficients;
 

--- a/src/pspc/sweep/Sweep.tpp
+++ b/src/pspc/sweep/Sweep.tpp
@@ -69,9 +69,9 @@ namespace Pspc {
       SweepTmpl< BasisFieldState<D> >::readParameters(in);
       
       // Read optional flags indicating which field types to output
-      readOptional<bool>(in, "writeCRGrid", writeCRGrid_);
-      readOptional<bool>(in, "writeCBasis", writeCBasis_);
-      readOptional<bool>(in, "writeWRGrid", writeWRGrid_);
+      readOptional(in, "writeCRGrid", writeCRGrid_);
+      readOptional(in, "writeCBasis", writeCBasis_);
+      readOptional(in, "writeWRGrid", writeWRGrid_);
    }
 
    /*

--- a/src/pspc/sweep/Sweep.tpp
+++ b/src/pspc/sweep/Sweep.tpp
@@ -27,6 +27,9 @@ namespace Pspc {
    template <int D>
    Sweep<D>::Sweep() 
     : SweepTmpl< BasisFieldState<D> >(PSPC_HISTORY_CAPACITY),
+      writeCRGrid_(false),
+      writeCBasis_(false),
+      writeWRGrid_(false),
       systemPtr_(0)
    {}
 
@@ -36,6 +39,9 @@ namespace Pspc {
    template <int D>
    Sweep<D>::Sweep(System<D> & system) 
     : SweepTmpl< BasisFieldState<D> >(PSPC_HISTORY_CAPACITY),
+      writeCRGrid_(false),
+      writeCBasis_(false),
+      writeWRGrid_(false),
       systemPtr_(&system)
    {}
 
@@ -52,6 +58,21 @@ namespace Pspc {
    template <int D>
    void Sweep<D>::setSystem(System<D>& system) 
    {  systemPtr_ = &system; }
+
+   /*
+   * Read parameters
+   */
+   template <int D>
+   void Sweep<D>::readParameters(std::istream& in)
+   {
+      // Call the base class's readParameters function.
+      SweepTmpl< BasisFieldState<D> >::readParameters(in);
+      
+      // Read optional flags indicating which field types to output
+      readOptional<bool>(in, "writeCRGrid", writeCRGrid_);
+      readOptional<bool>(in, "writeCBasis", writeCBasis_);
+      readOptional<bool>(in, "writeWRGrid", writeWRGrid_);
+   }
 
    /*
    * Check allocation of one state object, allocate if necessary.

--- a/src/pspc/sweep/Sweep.tpp
+++ b/src/pspc/sweep/Sweep.tpp
@@ -265,18 +265,8 @@ namespace Pspc {
                                           system().w().basis(), 
                                           system().unitCell());
 
-      // Write c fields
-      outFileName = baseFileName_;
-      outFileName += indexString;
-      outFileName += "_c";
-      outFileName += ".bf";
-      UTIL_CHECK(system().hasCFields());
-      system().fieldIo().writeFieldsBasis(outFileName, 
-                                          system().c().basis(), 
-                                          system().unitCell());
-
-      // Write c rgrid files
-      if (writeRhoRGrid_) {
+      // Optionally write c rgrid files
+      if (writeCRGrid_) {
          outFileName = baseFileName_;
          outFileName += indexString;
          outFileName += "_c";
@@ -286,6 +276,28 @@ namespace Pspc {
                                              system().unitCell());
       }
 
+       // Optionally write c basis files
+      if (writeCBasis_) {
+         outFileName = baseFileName_;
+         outFileName += indexString;
+         outFileName += "_c";
+         outFileName += ".bf";
+         UTIL_CHECK(system().hasCFields());
+         system().fieldIo().writeFieldsBasis(outFileName, 
+                                             system().c().basis(), 
+                                             system().unitCell());
+      }
+
+      // Optionally write w rgrid files
+      if (writeWRGrid_) {
+         outFileName = baseFileName_;
+         outFileName += indexString;
+         outFileName += "_w";
+         outFileName += ".rf";
+         system().fieldIo().writeFieldsRGrid(outFileName, 
+                                             system().w().rgrid(), 
+                                             system().unitCell());
+      }
    }
 
    template <int D>

--- a/src/pspc/tests/iterator/in/film/system1D
+++ b/src/pspc/tests/iterator/in/film/system1D
@@ -41,7 +41,6 @@ System{
   LinearSweep{
     ns            5   
     baseFileName  out/sweep/
-    writeRhoRGrid 0
     nParameter    3   
     parameters[
                   cell_param  0  +0.1

--- a/src/pspg/System.tpp
+++ b/src/pspg/System.tpp
@@ -822,6 +822,12 @@ namespace Pspg
          }
          out << std::endl;
       }
+   
+      out << "Lattice parameters:" << std::endl << "     ";
+      for (int i = 0; i < unitCell().nParameter(); ++i) {
+         out << "  " << Dbl(unitCell().parameter(i), 18, 11);
+      }
+      out << std::endl << std::endl;
    }
 
    // W-Field Modifier Functions

--- a/src/pspg/field/FieldIo.tpp
+++ b/src/pspg/field/FieldIo.tpp
@@ -1283,7 +1283,7 @@ namespace Pspg
 
    template <int D>
    void FieldIo<D>::convertKGridToBasis(DArray< RDFieldDft<D> > const & in,
-                                        DArray< DArray<double>> & out) 
+                                        DArray< DArray<double> > & out) 
    const
    {
 

--- a/src/pspg/iterator/AmIteratorBasis.tpp
+++ b/src/pspg/iterator/AmIteratorBasis.tpp
@@ -11,6 +11,7 @@
 #include "AmIteratorBasis.h"
 #include <pspg/System.h>
 #include <pscf/inter/Interaction.h>
+#include <pscf/iterator/NanException.h>
 #include <pspg/field/RDField.h>
 #include <util/global.h>
 
@@ -79,7 +80,12 @@ namespace Pspg{
       UTIL_CHECK(b.capacity() == n);
       double product = 0.0;
       for (int i=0; i < n; ++i) {
-         product += a[i]*b[i];
+         // if either value is NaN, throw NanException
+         if (std::isnan(a[i]) || std::isnan(b[i])) { 
+            throw NanException("AmIteratorBasis::dotProduct", __FILE__,
+                               __LINE__, 0);
+         }
+         product += a[i] * b[i];
       } 
       return product;
    }
@@ -90,9 +96,15 @@ namespace Pspg{
    {
       const int n = a.capacity();
       double max = 0.0;
+      double value;
       for (int i = 0; i < n; i++) {
-         if (fabs(a[i]) > max)
-            max = fabs(a[i]);
+         value = a[i];
+         if (std::isnan(value)) { // if value is NaN, throw NanException
+            throw NanException("AmIteratorBasis::dotProduct", __FILE__,
+                               __LINE__, 0);
+         }
+         if (fabs(value) > max)
+            max = fabs(value);
       }
       return max;
    }

--- a/src/pspg/sweep/LinearSweep.tpp
+++ b/src/pspg/sweep/LinearSweep.tpp
@@ -26,7 +26,7 @@ namespace Pspg {
    void LinearSweep<D>::readParameters(std::istream& in)
    {
       // Call the base class's readParameters function.
-      SweepTmpl< BasisFieldState<D> >::readParameters(in);
+      Sweep<D>::readParameters(in);
       
       // Read in the number of sweep parameters and allocate.
       this->read(in, "nParameter", nParameter_);

--- a/src/pspg/sweep/Sweep.h
+++ b/src/pspg/sweep/Sweep.h
@@ -48,6 +48,13 @@ namespace Pspg {
       */
       void setSystem(System<D>& system);
 
+      /**
+      * Read parameters from param file.
+      * 
+      * \param in Input stream from param file.
+      */
+      virtual void readParameters(std::istream& in);
+
       // Public members inherited from base class template SweepTmpl
       using SweepTmpl< BasisFieldState<D> >::historyCapacity;
       using SweepTmpl< BasisFieldState<D> >::historySize;
@@ -127,14 +134,21 @@ namespace Pspg {
       System<D>& system()
       {  return *systemPtr_; }
 
-      // Protected members inherited from base class template SweepTmpl
+      /// Whether to write real space concentration field files. 
+      bool writeCRGrid_;
+
+      /// Whether to write concentration field files in basis format. 
+      bool writeCBasis_;
+
+      /// Whether to write real space potential field files. 
+      bool writeWRGrid_;
+
+      // Protected members inherited from base classes
       using SweepTmpl< BasisFieldState<D> >::ns_;
       using SweepTmpl< BasisFieldState<D> >::baseFileName_;
-      using SweepTmpl< BasisFieldState<D> >::writeCRGrid_;
-      using SweepTmpl< BasisFieldState<D> >::writeCBasis_;
-      using SweepTmpl< BasisFieldState<D> >::writeWRGrid_;
       using SweepTmpl< BasisFieldState<D> >::initialize;
       using SweepTmpl< BasisFieldState<D> >::setCoefficients;
+      using ParamComposite::readOptional;
 
    private:
 

--- a/src/pspg/sweep/Sweep.h
+++ b/src/pspg/sweep/Sweep.h
@@ -130,7 +130,9 @@ namespace Pspg {
       // Protected members inherited from base class template SweepTmpl
       using SweepTmpl< BasisFieldState<D> >::ns_;
       using SweepTmpl< BasisFieldState<D> >::baseFileName_;
-      using SweepTmpl< BasisFieldState<D> >::writeRhoRGrid_;
+      using SweepTmpl< BasisFieldState<D> >::writeCRGrid_;
+      using SweepTmpl< BasisFieldState<D> >::writeCBasis_;
+      using SweepTmpl< BasisFieldState<D> >::writeWRGrid_;
       using SweepTmpl< BasisFieldState<D> >::initialize;
       using SweepTmpl< BasisFieldState<D> >::setCoefficients;
 

--- a/src/pspg/sweep/Sweep.tpp
+++ b/src/pspg/sweep/Sweep.tpp
@@ -71,9 +71,9 @@ namespace Pspg {
       SweepTmpl< BasisFieldState<D> >::readParameters(in);
       
       // Read optional flags indicating which field types to output
-      readOptional<bool>(in, "writeCRGrid", writeCRGrid_);
-      readOptional<bool>(in, "writeCBasis", writeCBasis_);
-      readOptional<bool>(in, "writeWRGrid", writeWRGrid_);
+      readOptional(in, "writeCRGrid", writeCRGrid_);
+      readOptional(in, "writeCBasis", writeCBasis_);
+      readOptional(in, "writeWRGrid", writeWRGrid_);
    }
 
    /*

--- a/src/pspg/sweep/Sweep.tpp
+++ b/src/pspg/sweep/Sweep.tpp
@@ -276,15 +276,8 @@ namespace Pspg {
       outFileName += ".bf";
       system().writeWBasis(outFileName);
 
-      // Write c fields
-      outFileName = baseFileName_;
-      outFileName += indexString;
-      outFileName += "_c";
-      outFileName += ".bf";
-      system().writeCBasis(outFileName);
-
-      // Write c rgrid files
-      if (writeRhoRGrid_) {
+      // Optionally write c rgrid files
+      if (writeCRGrid_) {
         outFileName = baseFileName_;
         outFileName += indexString;
         outFileName += "_c";
@@ -292,6 +285,23 @@ namespace Pspg {
         system().writeCRGrid(outFileName);
       }
 
+      // Optionally write c basis files
+      if (writeCBasis_) {
+         outFileName = baseFileName_;
+         outFileName += indexString;
+         outFileName += "_c";
+         outFileName += ".bf";
+         system().writeCBasis(outFileName);
+      }
+
+      // Optionally write w rgrid files
+      if (writeWRGrid_) {
+        outFileName = baseFileName_;
+        outFileName += indexString;
+        outFileName += "_w";
+        outFileName += ".rf";
+        system().writeWRGrid(outFileName);
+      }
    }
 
    template <int D>

--- a/src/pspg/sweep/Sweep.tpp
+++ b/src/pspg/sweep/Sweep.tpp
@@ -29,6 +29,9 @@ namespace Pspg {
    template <int D>
    Sweep<D>::Sweep() 
     : SweepTmpl< BasisFieldState<D> >(PSPG_HISTORY_CAPACITY),
+      writeCRGrid_(false),
+      writeCBasis_(false),
+      writeWRGrid_(false),
       systemPtr_(0)
    {}
 
@@ -38,6 +41,9 @@ namespace Pspg {
    template <int D>
    Sweep<D>::Sweep(System<D> & system) 
     : SweepTmpl< BasisFieldState<D> >(PSPG_HISTORY_CAPACITY),
+      writeCRGrid_(false),
+      writeCBasis_(false),
+      writeWRGrid_(false),
       systemPtr_(&system)
    {}
 
@@ -54,6 +60,21 @@ namespace Pspg {
    template <int D>
    void Sweep<D>::setSystem(System<D>& system) 
    {  systemPtr_ = &system; }
+
+   /*
+   * Read parameters
+   */
+   template <int D>
+   void Sweep<D>::readParameters(std::istream& in)
+   {
+      // Call the base class's readParameters function.
+      SweepTmpl< BasisFieldState<D> >::readParameters(in);
+      
+      // Read optional flags indicating which field types to output
+      readOptional<bool>(in, "writeCRGrid", writeCRGrid_);
+      readOptional<bool>(in, "writeCBasis", writeCBasis_);
+      readOptional<bool>(in, "writeWRGrid", writeWRGrid_);
+   }
 
    /*
    * Check allocation of one state object, allocate if necessary.


### PR DESCRIPTION
The biggest change in this PR is the addition of the NanException class in pscf/iterator/, which is used in a try-catch block of AmIteratorTmpl.tpp to catch the appearance of a NaN value in the AmIterator residual without crashing the whole program. This has been briefly tested on some examples that are known to generate NaN values in the residual, and the new code works as-designed. However, some implementations of the g++ compiler will basically ignore NaN values because of the `-ffast-math` tag, which prevents NanExceptions from being thrown in the first place. This is an unaddressed issue in the current pull request, and will be addressed later. Additionally, I have not yet figured out how to incorporate this NanException into pspg::AmIteratorGrid, which performs all of its arithmetic on the GPU, so that should be the subject of a future update as well.

Other changes include edits to the Sweep param file block, which now contains optional writeCRGrid, writeCBasis, and writeWRGrid inputs to control which fields are output at each sweep step. The System::writeThermo method (in pspg and pspc) now outputs the lattice parameters for any calculation where isFlexible=true. 

Finally, some documentation was updated to address certain aspects of the thin film feature, such as its inability to be paired with the COMPUTE command and its poor performance when paired with the reuseState feature. 

All unit tests have been run, and they pass successfully.