### PR TITLE
Hold ds constant rather than ns in fd1d::Block::setLength

### DIFF
--- a/src/fd1d/solvers/Block.h
+++ b/src/fd1d/solvers/Block.h
@@ -54,9 +54,9 @@ namespace Fd1d
       /**
       * Set length and readjust ds_ accordingly.
       *
-      * \param length  length (# of monomers) for this block
+      * \param newLength  length (# of monomers) for this block
       */
-      virtual void setLength(double length);
+      virtual void setLength(double newLength);
 
       /**
       * Set Crank-Nicholson solver for this block.
@@ -131,8 +131,11 @@ namespace Fd1d
       /// Pointer to associated Domain object.
       Domain const * domainPtr_;
 
-      /// Contour length step size.
+      /// Contour length step size (actual step size for this block).
       double ds_;
+
+      // Contour length step size (value input in param file).
+      double dsTarget_;
 
       /// Number of contour length steps = # grid points - 1.
       int ns_;

--- a/src/fd1d/solvers/Propagator.cpp
+++ b/src/fd1d/solvers/Propagator.cpp
@@ -31,6 +31,9 @@ namespace Fd1d
    Propagator::~Propagator()
    {}
 
+   /*
+   * Allocate memory used by this propagator.
+   */
    void Propagator::allocate(int ns, int nx)
    {
       ns_ = ns;
@@ -41,6 +44,30 @@ namespace Fd1d
       }
       isAllocated_ = true;
    }
+
+   /*
+   * Reallocate memory used by this propagator using new ns value.
+   */
+   void Propagator::reallocate(int ns)
+   {
+      UTIL_CHECK(isAllocated_);
+      UTIL_CHECK(ns_ != ns);
+      ns_ = ns;
+
+      // Deallocate memory previously used by this propagator.
+      // NOTE: DArray::deallocate() calls "delete [] ptr", where ptr is a 
+      // pointer to the underlying C array. This will call the destructor
+      // for each element in the underlying C array, freeing all memory 
+      // that was allocated to the objects stored in the DArray.
+      qFields_.deallocate();
+
+      // Allocate memory in qFields_ using new value of ns
+      qFields_.allocate(ns);
+      for (int i = 0; i < ns; ++i) {
+         qFields_[i].allocate(nx_);
+      }
+   }
+
 
    bool Propagator::isAllocated() const
    {  return isAllocated_; }

--- a/src/fd1d/solvers/Propagator.h
+++ b/src/fd1d/solvers/Propagator.h
@@ -78,6 +78,21 @@ namespace Fd1d
       void allocate(int ns, int nx);
 
       /**
+      * Reallocate memory used by this propagator.
+      * 
+      * This function is used when the value of ns is changed,
+      * which occurs during some parameter sweeps. 
+      * 
+      * The parameter ns is the number of values of s at which
+      * q(r,s) is calculated, including the end values at the
+      * terminating vertices. This is one more than the number 
+      * of contour variable steps. 
+      * 
+      * \param ns number of slices (including end points)
+      */ 
+      void reallocate(int ns);
+
+      /**
       * Solve the modified diffusion equation (MDE) for this block.
       *
       * This function computes an initial QField at the head of this

--- a/src/pspg/field/FieldIo.tpp
+++ b/src/pspg/field/FieldIo.tpp
@@ -1176,7 +1176,7 @@ namespace Pspg
             if (std::isnan(component.imag())) componentError = true;
             #endif
             coefficient = wavePtr->coeff;
-            #if UTIL_DEUG
+            #if UTIL_DEBUG
             if (std::isnan(coefficient.real())) componentError = true;
             if (std::isnan(coefficient.imag())) componentError = true;
             if (std::isnormal(coefficient))     componentError = true;


### PR DESCRIPTION
This PR makes the same modification as the previous PR, but in fd1d. ds now remains (nearly) constant during a sweep of block length, rather than ns. fd1d unit tests all pass, and a quick test of a block length sweep was performed to ensure that the intended behavior occurs, and it works as intended.