### PR TITLE
Add inverseId parameter to Basis::Wave, fix handling of implicit waves

### DIFF
--- a/src/prdc/crystal/Basis.h
+++ b/src/prdc/crystal/Basis.h
@@ -78,7 +78,7 @@ namespace Prdc {
    * listed as as a consecutive block. Wavevectors within each star are 
    * listed in order of decreasing order as determined by the integer 
    * indices, as defined by the member function Wave::indicesBz, with more
-   * signficant digits on the left. For example, the waves of the {211} 
+   * signficant digits on the left. For example, the waves of the {111} 
    * star of a cubic structure with full cubic symmetry will be listed 
    * in the order:
    * \code
@@ -391,6 +391,11 @@ namespace Prdc {
          int starId;
 
          /**
+         * Index of the wave that is the inverse of this wavevector.
+         */
+         int inverseId;
+
+         /**
          * Is this wave represented implicitly in DFT of real field?
          * 
          * In the discrete Fourier transform (DFT) of a real function, 
@@ -413,6 +418,7 @@ namespace Prdc {
             indicesDft(0),
             indicesBz(0),
             starId(0),
+            inverseId(-1),
             implicit(false),
             sqNorm(0.0)
          {}
@@ -434,7 +440,7 @@ namespace Prdc {
       * The wavevectors in a star form a continuous block within the array
       * waves defined by the Basis classes.  Within this block, waves are 
       * listed in descending lexigraphical order of their integer (ijk) 
-      * indices as given by Basis::Wave::indexBz.
+      * indices as given by Basis::Wave::indicesBz.
       */
       class Star 
       {
@@ -452,7 +458,10 @@ namespace Prdc {
          int beginId; 
 
          /**
-         * Wave index of last wavevector in star.
+         * Wave index of first wavevector of the next star.
+         * 
+         * This index is one past the wave index of the last wavevector of 
+         * this star.
          */
          int endId;  
 
@@ -486,9 +495,9 @@ namespace Prdc {
          int invertFlag; 
 
          /**
-         * Integer indices indexBz of a characteristic wave of this star.
+         * Integer indices indicesBz of a characteristic wave of this star.
          *
-         * Wave given here is the value of indexBz for a characteristic
+         * Wave given here is the value of indicesBz for a characteristic
          * wave for the star.  For invertFlag = 0 or 1, the characteristic
          * wave is the first wave in the star.  For invertFlag = -1, this 
          * is the negation of the waveBz of the partner star for which

--- a/src/prdc/crystal/Basis.tpp
+++ b/src/prdc/crystal/Basis.tpp
@@ -184,11 +184,9 @@ namespace Prdc {
       IntVec<D> rootVecDft;  // DFT indices for root of this star
       IntVec<D> vec;         // Indices of temporary wavevector
       IntVec<D> nVec;        // Indices of negation of a wavevector
-      int listId = 0;        // id for this list
       int listBegin = 0;     // id of first wave in this list
       int listEnd = 0;       // (id of last wave in this list) + 1
       int listSize;          // listEnd - listBegin
-      int starId = 0;        // id for this star
       int starBegin = 0;     // id of first wave in this star
       int i, j, k;
       bool cancel;
@@ -587,7 +585,6 @@ namespace Prdc {
                }
 
                stars_.append(newStar);
-               ++starId;
                starBegin = newStar.endId;
 
             }
@@ -621,7 +618,6 @@ namespace Prdc {
             // the coeff may not be unity for the first or last wave in
             // the star.
 
-            ++listId;
             listBegin = listEnd;
          } 
          // Finished processing a list of waves of equal norm

--- a/src/prdc/crystal/Basis.tpp
+++ b/src/prdc/crystal/Basis.tpp
@@ -1068,6 +1068,16 @@ namespace Prdc {
             std::cout << "-G = " << waves_[iwp].indicesBz << std::endl;
             return false;
          }
+
+         // Check that either this wave or its inverse is explicit
+         if (waves_[iw].implicit == true && waves_[iwp].implicit == true) 
+         {
+            std::cout << "\n";
+            std::cout << "Wave and its inverse are both implicit";
+            std::cout << "+G = " << waves_[iw].indicesBz << std::endl;
+            std::cout << "-G = " << waves_[iwp].indicesBz << std::endl;
+            return false;
+         }
       }
 
       // Loop over all stars (elements of stars_ array)

--- a/src/rpc/field/FieldIo.tpp
+++ b/src/rpc/field/FieldIo.tpp
@@ -1987,7 +1987,6 @@ namespace Rpc {
          DArray<RField<3> > outFields;
          UnitCell<3> cell;
          IntVec<3> dimensions;
-         int rank = 0;
          // Set dimensions
          dimensions[0] = meshDimensions[0];
          dimensions[1] = meshDimensions[1];

--- a/src/rpc/field/FieldIo.tpp
+++ b/src/rpc/field/FieldIo.tpp
@@ -1478,6 +1478,7 @@ namespace Rpc {
       int rank;                                // dft grid rank of wave
       int is;                                  // star index
       int ib;                                  // basis index
+      int iw;                                  // wave index
 
       // Initialize all components to zero
       for (is = 0; is < basis().nBasis(); ++is) {
@@ -1502,7 +1503,7 @@ namespace Rpc {
             // Choose a wave in the star that is not implicit
             int beginId = starPtr->beginId;
             int endId = starPtr->endId;
-            int iw = 0;
+            iw = 0;
             bool isImplicit = true;
             while (isImplicit) {
                wavePtr = &basis().wave(beginId + iw);
@@ -1530,13 +1531,15 @@ namespace Rpc {
          if (starPtr->invertFlag == 1) {
 
             // Identify a characteristic wave that is not implicit:
-            // Either the first wave of the 1st star or last wave of 2nd
+            // Either the first wave of the 1st star or its inverse
+            // in the second star
             wavePtr = &basis().wave(starPtr->beginId);
             UTIL_CHECK(wavePtr->starId == is);
             if (wavePtr->implicit) {
+               iw = wavePtr->inverseId;
                starPtr = &(basis().star(is+1));
                UTIL_CHECK(starPtr->invertFlag == -1);
-               wavePtr = &basis().wave(starPtr->endId - 1);
+               wavePtr = &basis().wave(iw);
                UTIL_CHECK(!(wavePtr->implicit));
                UTIL_CHECK(wavePtr->starId == is+1);
             }

--- a/src/rpg/field/FieldIo.tpp
+++ b/src/rpg/field/FieldIo.tpp
@@ -1348,12 +1348,14 @@ namespace Rpg {
          if (starPtr->invertFlag == 1) {
 
             // Identify a characteristic wave that is not implicit:
-            // Either first wave of 1st star or last wave of 2nd star.
+            // Either the first wave of the 1st star or its inverse
+            // in the second star
             wavePtr = &basis().wave(starPtr->beginId);
             if (wavePtr->implicit) {
+               iw = wavePtr->inverseId;
                starPtr = &(basis().star(is+1));
                UTIL_CHECK(starPtr->invertFlag == -1);
-               wavePtr = &basis().wave(starPtr->endId - 1);
+               wavePtr = &basis().wave(iw);
                UTIL_CHECK(!(wavePtr->implicit));
                UTIL_CHECK(wavePtr->starId == is+1);
             }

--- a/src/rpg/tests/system/in/solution/lam_open/param.grid
+++ b/src/rpg/tests/system/in/solution/lam_open/param.grid
@@ -36,7 +36,7 @@ System{
   }
   AmIteratorGrid{
     epsilon      5.0e-11
-    maxItr       600
+    maxItr       1000
     maxHist      30
     isFlexible   1
   }


### PR DESCRIPTION
This pull request contains 4 commits. 

In the first commit, a new parameter `inverseId` is added to the `Basis::Wave` class to track the index of the inverse of that wave. During construction of the basis these indices are assigned, and the method `Basis::isValid` has been modified to take advantage of this new parameter as a quick way to find the inverse of the wave. Also, new tests were added to `Basis::isValid` to make sure these indices were assigned correctly. This commit contains changes to `prdc/Basis.h` and `prdc/Basis.tpp`.

In the second commit, a few unused variables were deleted in `prdc/Basis.tpp` and `rpc/field/FieldIo.tpp`. These variables were causing compiler warnings because they were not used, so I removed them.

In the third commit, I fixed the bug in `FieldIo` (both `rpc` and `rpg`) that causes an error for the `P_-4_b_2` space group. In the method `convertKGridToBasis` when identifying a characteristic wave for a star, if an implicit wave is found, the inverse of that wave is used as the characteristic wave instead, since the inverse must be explicit. Previously, the index of the inverse was assumed to be known, but this turned out to be untrue for stars on the edge of the BZ. So now, we use the new inverseId member of the Wave class to ensure that we accurately identify the inverse wave. This commit also contains a new test added to `Basis::isValid` to make sure that, between a wave and its inverse, at least one wave is explicit.

In the fourth commit, I simply changed `maxItr` from 600 to 1000 in an example in `rpg/tests`, because this unit test was failing when ran on an A100 GPU. For some reason, it takes ~700 iterations on an A100 but only 400 on our K40 GPU. 

After all four commits, I checked all unit tests (running the `rpg` unit tests on both the K40 and A100 GPUs) and they all pass. I also checked that I can now successfully run a calculation with the `P_-4_b_2` space group that previously gave me an error, and indeed the calculation worked as desired. 