### PR TITLE
Move Iterator::setParameterTypes -> ParameterModifier::getParameterTypes

### DIFF
--- a/src/pscf/sweep/ParameterModifier.h
+++ b/src/pscf/sweep/ParameterModifier.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include "util/containers/DArray.h"
+#include "pscf/sweep/ParameterType.h" // base class
 
 /*
 * PSCF - Polymer Self-Consistent Field Theory
@@ -18,11 +19,15 @@ namespace Pscf {
    /**
    * Base class allowing subclasses to define sweepable parameters.
    * 
-   * The SweepTmpl class defines a method, addParameterTypes(), which
-   * allows custom "specialized" sweepable parameters to be added to
-   * the sweep class at run time. Any object with a specialized sweep
-   * parameter must be a subclass of ParameterModifier, and must 
-   * redefine the two virtual methods setParameter and getParameter.
+   * This class, along with SweepTmpl, define an interface which allows 
+   * "specialized" sweepable parameters to be added to the Sweep class 
+   * at run time. Any object with a specialized sweep parameter must 
+   * be a subclass of ParameterModifier, and must redefine the three 
+   * virtual methods getParameterTypes, setParameter, and getParameter.
+   * The Sweep object is then responsible for calling the method 
+   * getParameterTypes for any ParameterModifier in the system and 
+   * adding the parameters to its list of specialized sweep parameters.
+   * This should happen in the Sweep class constructor.
    * 
    * This interface was designed to allow objects whose class is 
    * determined at run time (i.e., an object created by a Factory) to
@@ -45,6 +50,17 @@ namespace Pscf {
       * Destructor.
       */
       ~ParameterModifier();
+
+      /**
+      * Return specialized sweep parameter types to add to the Sweep object.
+      * 
+      * This method should be called by the Sweep object in its constructor.
+      * If the ParameterModifier object does not have any specialized sweep 
+      * parameters, this method can be left as implemented here, returning 
+      * an empty array.
+      */
+      virtual DArray<ParameterType> getParameterTypes()
+      {  return DArray<ParameterType>(); } // empty array
 
       /**
       * Set the value of a specialized sweep parameter.

--- a/src/pscf/sweep/ParameterType.cpp
+++ b/src/pscf/sweep/ParameterType.cpp
@@ -13,7 +13,15 @@ namespace Pscf {
    ParameterType::ParameterType()
     : name(),
       nId(0),
-      modifierPtr_(0)
+      modifierPtr(0)
+   {}
+
+   // Alternate constructor that sets all members
+   ParameterType::ParameterType(std::string name, int nId, 
+                                    ParameterModifier& modifier)
+    : name(name),
+      nId(nId),
+      modifierPtr(&modifier)
    {}
 
    // Destructor

--- a/src/pscf/sweep/ParameterType.h
+++ b/src/pscf/sweep/ParameterType.h
@@ -1,7 +1,7 @@
 #ifndef PSCF_PARAMETER_TYPE_H
 #define PSCF_PARAMETER_TYPE_H
 
-#include "pscf/sweep/ParameterModifier.h" // base class
+#include <string>
 
 /*
 * PSCF - Polymer Self-Consistent Field Theory
@@ -11,6 +11,8 @@
 */
 
 namespace Pscf {
+
+   class ParameterModifier; // Forward declaration, avoids circular reference
 
    /**
    * Declaration of a specialized sweep parameter type.
@@ -22,6 +24,8 @@ namespace Pscf {
    * is a subclass of ParameterModifier. This latter object is 
    * responsible for defining the setter/getter functions that
    * actually affect the sweepable parameter.
+   * 
+   * \ingroup Pscf_Sweep_Module
    */
    struct ParameterType 
    {
@@ -30,6 +34,15 @@ namespace Pscf {
       * Constructor.
       */
       ParameterType();
+
+      /**
+      * Alternate constructor that sets all members
+      * 
+      * \param name  String representing the name of this parameter
+      * \param nId  The number of indices needed to specify this parameter
+      * \param modifier  The ParameterModifier that owns this parameter
+      */
+      ParameterType(std::string name, int nId, ParameterModifier& modifier);
 
       /**
       * Destructor.
@@ -43,7 +56,7 @@ namespace Pscf {
       int nId;
 
       // Pointer to object that can get and set the parameter
-      ParameterModifier* modifierPtr_;
+      ParameterModifier* modifierPtr;
 
    };
 

--- a/src/pscf/sweep/SweepTmpl.h
+++ b/src/pscf/sweep/SweepTmpl.h
@@ -9,6 +9,7 @@
 */
 
 #include <util/param/ParamComposite.h>                     // base class
+#include <util/containers/DArray.h>
 #include <util/containers/GArray.h>
 #include <pscf/sweep/ParameterModifier.h>
 #include <pscf/sweep/ParameterType.h>
@@ -48,10 +49,11 @@ namespace Pscf {
       virtual void sweep();
 
       /**
-      * Add declaration of a specialized parameter type.
+      * Declare a specialized parameter type.
       * 
-      * This function adds a new ParameterType object to the
-      * array of declared specialized parameter types.
+      * This function creates a new ParameterType object using 
+      * the input parameters and adds this object to the array 
+      * of declared specialized parameter types.
       *
       * \param name  parameter string identifier
       * \param nId  number of associated integer indices
@@ -59,6 +61,26 @@ namespace Pscf {
       */
       void addParameterType(std::string name, int nId, 
                             ParameterModifier& modifier);
+
+      /**
+      * Declare a specialized parameter type.
+      * 
+      * This function adds a new ParameterType object to the
+      * array of declared specialized parameter types.
+      *
+      * \param paramType  parameterType object defining the sweep parameter
+      */
+      void addParameterType(ParameterType paramType);
+
+      /**
+      * Declare an array of specialized parameter types.
+      * 
+      * This function adds an array of new ParameterType objects to the
+      * array of declared specialized parameter types.
+      *
+      * \param paramType  array of parameterType objects
+      */
+      void addParameterTypes(DArray<ParameterType> paramTypes);
 
    protected:
 

--- a/src/pscf/sweep/SweepTmpl.tpp
+++ b/src/pscf/sweep/SweepTmpl.tpp
@@ -160,8 +160,36 @@ namespace Pscf {
       ParameterType paramType;
       paramType.name = name;
       paramType.nId = nId;
-      paramType.modifierPtr_ = &modifier;
+      paramType.modifierPtr = &modifier;
       parameterTypes_.append(paramType);
+   }
+
+   template <class State>
+   void SweepTmpl<State>::addParameterType(ParameterType paramType)
+   {
+      // Check if parameterTypes_ already has an element with this name
+      if (parameterTypes_.size() > 0) {
+         for (int i = 0; i < parameterTypes_.size(); ++i) {
+            UTIL_CHECK(parameterTypes_[i].name != paramType.name);
+         }
+      }
+
+      parameterTypes_.append(paramType);
+   }
+
+   template <class State>
+   void SweepTmpl<State>::addParameterTypes(DArray<ParameterType> paramTypes)
+   {
+      for (int i = 0; i < paramTypes.capacity(); i++) {
+         // Check if parameterTypes_ already has an element with this name
+         if (parameterTypes_.size() > 0) {
+            for (int j = 0; j < parameterTypes_.size(); j++) {
+               UTIL_CHECK(parameterTypes_[j].name != paramTypes[i].name);
+            }
+         }
+         
+         parameterTypes_.append(paramTypes[i]);
+      }
    }
 
    /*

--- a/src/r1d/iterator/Iterator.h
+++ b/src/r1d/iterator/Iterator.h
@@ -56,14 +56,6 @@ namespace R1d
       */
       virtual int solve(bool isContinuation = false) = 0;
 
-      /**
-      * Add specialized sweep parameter types to the Sweep object
-      * 
-      * \param sweep  The sweep object to which parameters will be added
-      */
-      virtual void addParameterTypes(Sweep& sweep)
-      {}
-
    };
 
 } // namespace R1d

--- a/src/r1d/sweep/Sweep.cpp
+++ b/src/r1d/sweep/Sweep.cpp
@@ -37,7 +37,7 @@ namespace R1d
       setClassName("Sweep"); 
       fieldIo_.associate(sys.domain(), sys.fileMaster());
 
-      system().iterator().addParameterTypes(*this);
+      addParameterTypes(system().iterator().getParameterTypes());
    }
 
    /*

--- a/src/r1d/sweep/SweepParameter.cpp
+++ b/src/r1d/sweep/SweepParameter.cpp
@@ -192,7 +192,7 @@ namespace R1d {
       } else if (type_ == Solvent) {
          return systemPtr_->mixture().solvent(id(0)).size();
       } else if (type_ == Special) {
-         ParameterModifier* modifier = parameterType().modifierPtr_;
+         ParameterModifier* modifier = parameterType().modifierPtr;
          std::string name = parameterType().name;
          return modifier->getParameter(name,id_);
       } else {
@@ -219,7 +219,7 @@ namespace R1d {
       } else if (type_ == Solvent) {
          systemPtr_->mixture().solvent(id(0)).setSize(newVal);
       } else if (type_ == Special) {
-         ParameterModifier* modifier = parameterType().modifierPtr_;
+         ParameterModifier* modifier = parameterType().modifierPtr;
          std::string name = parameterType().name;
          return modifier->setParameter(name,id_,newVal);
       } else {

--- a/src/rpc/iterator/FilmIteratorBase.h
+++ b/src/rpc/iterator/FilmIteratorBase.h
@@ -153,14 +153,12 @@ namespace Rpc
       bool isAthermal() const;
 
       /**
-      * Add specialized sweep parameter types to the Sweep object.
+      * Return specialized sweep parameter types to add to the Sweep object.
       * 
       * In this class, the two specialized sweep parameters are chi_top
       * and chi_bottom.
-      * 
-      * \param sweep  The sweep object to which parameters will be added
       */
-      void addParameterTypes(Sweep<D>& sweep);
+      DArray<ParameterType> getParameterTypes();
 
       /**
       * Set the value of a specialized sweep parameter.

--- a/src/rpc/iterator/FilmIteratorBase.tpp
+++ b/src/rpc/iterator/FilmIteratorBase.tpp
@@ -18,8 +18,10 @@
 #include "prdc/crystal/SpaceGroup.h"
 
 #include "pscf/math/RealVec.h"
+#include "pscf/sweep/ParameterType.h"
 
 #include "util/containers/FArray.h"
+#include "util/containers/DArray.h"
 #include "util/format/Dbl.h"
 
 #include <cmath>
@@ -488,14 +490,17 @@ namespace Rpc
    }
 
    /*
-   * Add specialized sweep parameter types chi_top and chi_bottom to 
-   * the Sweep object.
+   * Return specialized sweep parameter types to add to the Sweep object.
    */
    template <int D, typename IteratorType>
-   void FilmIteratorBase<D, IteratorType>::addParameterTypes(Sweep<D>& sweep)
+   DArray<ParameterType> 
+   FilmIteratorBase<D, IteratorType>::getParameterTypes()
    {
-      sweep.addParameterType("chi_top", 1, *this);
-      sweep.addParameterType("chi_bottom", 1, *this);
+      DArray<ParameterType> pTypes;
+      pTypes.allocate(2);
+      pTypes[0] = ParameterType("chi_top", 1, *this);
+      pTypes[1] = ParameterType("chi_bottom", 1, *this);
+      return pTypes;
    }
 
    /*

--- a/src/rpc/iterator/Iterator.h
+++ b/src/rpc/iterator/Iterator.h
@@ -70,14 +70,6 @@ namespace Rpc
       virtual void clearTimers() = 0;
 
       /**
-      * Add specialized sweep parameter types to the Sweep object
-      * 
-      * \param sweep  The sweep object to which parameters will be added
-      */
-      virtual void addParameterTypes(Sweep<D>& sweep)
-      {}
-
-      /**
       * Does this iterator use a symmetry-adapted Fourier basis?
       */
       bool isSymmetric() const

--- a/src/rpc/sweep/Sweep.h
+++ b/src/rpc/sweep/Sweep.h
@@ -61,6 +61,8 @@ namespace Rpc {
       virtual void readParameters(std::istream& in);
 
       // Public members inherited from base class template SweepTmpl
+      using SweepTmpl< BasisFieldState<D> >::addParameterTypes;
+      using SweepTmpl< BasisFieldState<D> >::addParameterType;
       using SweepTmpl< BasisFieldState<D> >::historyCapacity;
       using SweepTmpl< BasisFieldState<D> >::historySize;
       using SweepTmpl< BasisFieldState<D> >::nAccept;

--- a/src/rpc/sweep/Sweep.tpp
+++ b/src/rpc/sweep/Sweep.tpp
@@ -47,7 +47,7 @@ namespace Rpc {
    {
       // Get specialized sweep parameters from Iterator
       if (system().hasIterator()) {
-         system().iterator().addParameterTypes(*this);
+         addParameterTypes(system().iterator().getParameterTypes());
       }
    }
 

--- a/src/rpc/sweep/SweepParameter.tpp
+++ b/src/rpc/sweep/SweepParameter.tpp
@@ -203,7 +203,7 @@ namespace Rpc {
       } else if (type_ == Cell_Param) {
          return systemPtr_->unitCell().parameter(id(0));
       } else if (type_ == Special) {
-         ParameterModifier* modifier = parameterType().modifierPtr_;
+         ParameterModifier* modifier = parameterType().modifierPtr;
          std::string name = parameterType().name;
          return modifier->getParameter(name,id_);
       } else {
@@ -235,7 +235,7 @@ namespace Rpc {
          params[id(0)] = newVal;
          systemPtr_->setUnitCell(params);
       } else if (type_ == Special) {
-         ParameterModifier* modifier = parameterType().modifierPtr_;
+         ParameterModifier* modifier = parameterType().modifierPtr;
          std::string name = parameterType().name;
          return modifier->setParameter(name,id_,newVal);
       } else {

--- a/src/rpc/tests/iterator/FilmIteratorTest.h
+++ b/src/rpc/tests/iterator/FilmIteratorTest.h
@@ -493,7 +493,7 @@ public:
 
    void testSweep() // test sweep along chiBottom and lattice parameter
    {
-      // NOTE: this also tests that the addParameterTypes method works
+      // NOTE: this also tests that the getParameterTypes method works
       printMethod(TEST_FUNC);
       
       openLogFile("out/filmTestSweep.log");

--- a/src/rpc/tests/sweep/SweepTest.h
+++ b/src/rpc/tests/sweep/SweepTest.h
@@ -192,17 +192,17 @@ public:
 
       pType1.name = "test1";
       pType1.nId = 1;
-      pType1.modifierPtr_ = &modifier;
+      pType1.modifierPtr = &modifier;
       pTypes.append(pType1);
 
       pType2.name = "test2";
       pType2.nId = 2;
-      pType2.modifierPtr_ = &modifier;
+      pType2.modifierPtr = &modifier;
       pTypes.append(pType2);
 
       pType3.name = "test3";
       pType3.nId = 3;
-      pType3.modifierPtr_ = &modifier;
+      pType3.modifierPtr = &modifier;
       pTypes.append(pType3);
       Log::file() << pTypes.size() << std::endl;
 

--- a/src/rpg/iterator/Iterator.h
+++ b/src/rpg/iterator/Iterator.h
@@ -76,14 +76,6 @@ namespace Rpg
       virtual void clearTimers() = 0;
 
       /**
-      * Add specialized sweep parameter types to the Sweep object
-      * 
-      * \param sweep  The sweep object to which parameters will be added
-      */
-      virtual void addParameterTypes(Sweep<D>& sweep)
-      {}
-
-      /**
       * Does this iterator use a symmetry-adapted Fourier basis?
       */
       bool isSymmetric() const;

--- a/src/rpg/sweep/Sweep.h
+++ b/src/rpg/sweep/Sweep.h
@@ -58,6 +58,8 @@ namespace Rpg {
       virtual void readParameters(std::istream& in);
 
       // Public members inherited from base class template SweepTmpl
+      using SweepTmpl< BasisFieldState<D> >::addParameterTypes;
+      using SweepTmpl< BasisFieldState<D> >::addParameterType;
       using SweepTmpl< BasisFieldState<D> >::historyCapacity;
       using SweepTmpl< BasisFieldState<D> >::historySize;
       using SweepTmpl< BasisFieldState<D> >::nAccept;

--- a/src/rpg/sweep/Sweep.tpp
+++ b/src/rpg/sweep/Sweep.tpp
@@ -48,7 +48,7 @@ namespace Rpg {
    {
       // Get specialized sweep parameters from Iterator
       if (system().hasIterator()) {
-         system().iterator().addParameterTypes(*this);
+         addParameterTypes(system().iterator().getParameterTypes());
       }
    }
 

--- a/src/rpg/sweep/SweepParameter.tpp
+++ b/src/rpg/sweep/SweepParameter.tpp
@@ -212,7 +212,7 @@ namespace Rpg {
       } else if (type_ == Cell_Param) {
          return systemPtr_->unitCell().parameter(id(0));
       } else if (type_ == Special) {
-         ParameterModifier* modifier = parameterType().modifierPtr_;
+         ParameterModifier* modifier = parameterType().modifierPtr;
          std::string name = parameterType().name;
          return modifier->getParameter(name,id_);
       } else {
@@ -244,7 +244,7 @@ namespace Rpg {
          params[id(0)] = newVal;
          systemPtr_->setUnitCell(params);
       } else if (type_ == Special) {
-         ParameterModifier* modifier = parameterType().modifierPtr_;
+         ParameterModifier* modifier = parameterType().modifierPtr;
          std::string name = parameterType().name;
          return modifier->setParameter(name,id_,newVal);
       } else {

--- a/src/rpg/tests/sweep/SweepTest.h
+++ b/src/rpg/tests/sweep/SweepTest.h
@@ -193,17 +193,17 @@ public:
 
       pType1.name = "test1";
       pType1.nId = 1;
-      pType1.modifierPtr_ = &modifier;
+      pType1.modifierPtr = &modifier;
       pTypes.append(pType1);
 
       pType2.name = "test2";
       pType2.nId = 2;
-      pType2.modifierPtr_ = &modifier;
+      pType2.modifierPtr = &modifier;
       pTypes.append(pType2);
 
       pType3.name = "test3";
       pType3.nId = 3;
-      pType3.modifierPtr_ = &modifier;
+      pType3.modifierPtr = &modifier;
       pTypes.append(pType3);
       Log::file() << pTypes.size() << std::endl;
 


### PR DESCRIPTION
In our previous implementation of the `ParameterModifier` feature, `ParameterModifier` had two methods, `setParameter` and `getParameter`. The subclasses of `ParameterModifier` were responsible for creating a method to add the specialized parameter(s) to the `Sweep` object. For example, `rpc::Iterator` has a virtual method called `addParameterTypes`, which is called by `rpc::Sweep` in its constructor method to add any specialized sweep parameters from the `Iterator`. This was OK, but I felt like it would be more appropriate if `ParameterModifier` itself contained a (virtual) method that was responsible for adding the specialized sweep parameters to the `Sweep` object. This way, all of the operations that are necessary for a `ParameterModifier` to work properly are actually laid out in the base class, rather than being left for the subclasses to define separately. This change will also make future development on the thin film code easier, so I decided to make the change.

The primary barrier to making this change was that the `ParameterModifier` needed to know the class type of the `Sweep` object to which it should send its `ParameterTypes`. In the `pscf` namespace, the only `Sweep` class is the `SweepTmpl<State>` template class, which requires a template parameter that we do not know. Therefore, it is easier to find a way for the `ParameterModifier` to send its `ParameterTypes` without any knowledge of the `Sweep` object. This is achieved in this pull request by the method `ParameterModifier::getParameterTypes()`, which requires no input parameters and returns a `DArray<ParameterType>` that contains all of the `ParameterType` objects associated with this `ParameterModifier`. A `Sweep` object must then have a method called `addParameterTypes(DArray<ParameterType>)` that can accept a `DArray` of `ParameterType` objects and add them all to its own `parameterTypes_` array. Then, the `Sweep` class can retrieve the `ParameterType` objects from the `Iterator` with one line of code, just as it did before:
`addParameterTypes(system().iterator().getParameterTypes())`

This change is preferable over the previous version of `ParameterModifier`, because now the `ParameterModifier` does not need to know anything about the system's `Sweep` object, and because it now contains a virtual method `getParameterTypes()` that defines the way in which subclasses will provide their ParameterType objects to the Sweep.

All unit tests have been ran, and they all pass.