### PR TITLE
Make WaveList compatible with complex fields

### DIFF
--- a/src/prdc/cpu/WaveList.h
+++ b/src/prdc/cpu/WaveList.h
@@ -33,6 +33,14 @@ namespace Cpu {
    * should be called, which will effectively reset the WaveList object so
    * that the wavevector properties will need to be recalculated before 
    * being used.
+   * 
+   * This object calculates these wavevector properties for a mesh of grid
+   * points in k-space. If a calculation only requires real-valued fields, 
+   * PSCF uses a reduced-size k-space mesh, as output by FFTW. However, a 
+   * full-sized k-space mesh (the same size as the real-space mesh) is 
+   * necessary when dealing with complex-valued fields. The k-space mesh
+   * used by a WaveList object is determined by the parameter isRealField,
+   * which is assigned in the constructor and cannot later be changed. 
    */
    template <int D>
    class WaveList
@@ -41,8 +49,10 @@ namespace Cpu {
 
       /**
       * Constructor.
+      * 
+      * \param isRealField  Will this WaveList be used for real-valued fields?
       */
-      WaveList();
+      WaveList(bool isRealField = true);
 
       /**
       * Destructor
@@ -137,6 +147,9 @@ namespace Cpu {
       * each gridpoint. The boolean represents whether the inverse of the
       * wave at the given gridpoint is an implicit wave. Implicit here is
       * used to mean any wave that is outside the bounds of the k-grid.
+      * 
+      * This method will throw an error if isRealField == false, because
+      * there are no implicit inverses in such a case.
       */
       DArray<bool> const & implicitInverse() const;
 
@@ -163,6 +176,12 @@ namespace Cpu {
       */ 
       bool hasdKSq() const
       {  return hasdKSq_; }
+
+      /**
+      * Does this WaveList correspond to real-valued fields?
+      */ 
+      bool isRealField() const
+      {  return isRealField_; }
 
    private:
 
@@ -195,6 +214,9 @@ namespace Cpu {
 
       /// Has the dKSq array been computed?
       bool hasdKSq_;
+
+      /// Will this WaveList be used for real-valued fields?
+      bool isRealField_;
 
       /// Pointer to associated UnitCell<D> object
       UnitCell<D> const * unitCellPtr_;
@@ -254,6 +276,7 @@ namespace Cpu {
    DArray<bool> const & WaveList<D>::implicitInverse() const
    {  
       UTIL_CHECK(isAllocated_);
+      UTIL_CHECK(isRealField_);
       return implicitInverse_;
    }
 

--- a/src/prdc/cpu/WaveList.h
+++ b/src/prdc/cpu/WaveList.h
@@ -70,7 +70,7 @@ namespace Cpu {
       /**
       * Clear all internal data that depends on lattice parameters.
       * 
-      * Sets hasKSq_ and hasdKSq_ to false. Sets hasMinimumImages_ to
+      * Sets hasKSq_ and hasdKSq_ to false. Sets hasMinImages_ to
       * false only if the unit cell type has variable angles.
       */
       void clearUnitCellData();
@@ -103,19 +103,21 @@ namespace Cpu {
       /**
       * Get the array of minimum image vectors by const reference.
       * 
-      * This function returns an array of size kSize in which each element
-      * element is an IntVec<D> containing the integer coordinates of the 
-      * minimum image of one wavevector in the k-space mesh used for the
-      * DFT of real data. 
+      * This function returns an array in which each element is an IntVec<D>
+      * containing the integer coordinates of the minimum image of one 
+      * wavevector in the k-space mesh used for the DFT. If isRealField is
+      * true, this k-space mesh is smaller than the real-space mesh. 
+      * Otherwise, it is the same size.
       */
       DArray< IntVec<D> > const & minImages() const;
 
       /**
       * Get the kSq array on the device by const reference.
       *
-      * This function returns an array of size kSize in which each element
-      * is the square magnitude |k|^2 of a wavevector k in the k-space
-      * mesh used for a DFT of real data.
+      * This function returns an array in which each element is the square
+      * magnitude |k|^2 of a wavevector k in the k-space mesh used for the 
+      * DFT. If isRealField is true, this k-space mesh is smaller than the 
+      * real-space mesh. Otherwise, it is the same size.
       */
       RField<D> const & kSq() const;
 
@@ -127,6 +129,12 @@ namespace Cpu {
       * prefactor is 2.0 for waves that have an implicit inverse and 1.0
       * otherwise. The choice of prefactor is designed to simplify use
       * of the array to compute stress.
+      * 
+      * Each element corresponds to one wavevector k in the k-space mesh 
+      * used for the DFT. If isRealField is true, this k-space mesh is 
+      * smaller than the real-space mesh. Otherwise, it is the same size.
+      * In the latter case, there are no implicit waves, so the prefactor
+      * is always 1.0.
       *
       * \param i index of lattice parameter
       */
@@ -162,8 +170,8 @@ namespace Cpu {
       /**
       * Have minimum images been computed?
       */ 
-      bool hasMinimumImages() const
-      {  return hasMinimumImages_; }
+      bool hasMinImages() const
+      {  return hasMinImages_; }
 
       /**
       * Has the kSq array been computed?
@@ -197,17 +205,29 @@ namespace Cpu {
       /// Array indicating whether a given gridpoint has an implicit partner
       DArray<bool> implicitInverse_;
 
-      /// Dimensions of the mesh in reciprocal space.
+      /**
+      * Dimensions of the mesh in reciprocal space.
+      * 
+      * If isRealField_, the reciprocal-space grid is smaller than the 
+      * real-space grid, as output by FFTW. Otherwise, the two grids
+      * are the same size.
+      */ 
       IntVec<D> kMeshDimensions_;
 
-      /// Number of grid points in reciprocal space.
+      /**
+      * Number of grid points in reciprocal space.
+      * 
+      * If isRealField_, the reciprocal-space grid is smaller than the 
+      * real-space grid, as output by cuFFT. Otherwise, the two grids
+      * are the same size.
+      */ 
       int kSize_;
 
       /// Has memory been allocated for arrays?
       bool isAllocated_;
 
       /// Have minimum images been computed?
-      bool hasMinimumImages_;
+      bool hasMinImages_;
 
       /// Has the kSq array been computed?
       bool hasKSq_;
@@ -239,7 +259,7 @@ namespace Cpu {
    inline 
    DArray< IntVec<D> > const & WaveList<D>::minImages() const
    {
-      UTIL_CHECK(hasMinimumImages_);
+      UTIL_CHECK(hasMinImages_);
       return minImages_; 
    }
    

--- a/src/prdc/cpu/WaveList.tpp
+++ b/src/prdc/cpu/WaveList.tpp
@@ -29,7 +29,7 @@ namespace Cpu {
    WaveList<D>::WaveList(bool isRealField)
     : kSize_(0),
       isAllocated_(false),
-      hasMinimumImages_(false),
+      hasMinImages_(false),
       hasKSq_(false),
       hasdKSq_(false),
       unitCellPtr_(nullptr),
@@ -105,7 +105,7 @@ namespace Cpu {
       hasKSq_ = false;
       hasdKSq_ = false;
       if (hasVariableAngle<D>(unitCell().lattice())) {
-         hasMinimumImages_ = false;
+         hasMinImages_ = false;
       }
    }
 
@@ -115,7 +115,7 @@ namespace Cpu {
    template <int D>
    void WaveList<D>::computeMinimumImages() 
    {
-      if (hasMinimumImages_) return; // min images already calculated
+      if (hasMinImages_) return; // min images already calculated
 
       // Precondition
       UTIL_CHECK(isAllocated_);
@@ -132,7 +132,7 @@ namespace Cpu {
          kSq_[rank] = unitCell().ksq(minImages_[rank]);
       }
 
-      hasMinimumImages_ = true;
+      hasMinImages_ = true;
       hasKSq_ = true;
    }
 
@@ -146,7 +146,7 @@ namespace Cpu {
       if (hasKSq_) return; 
 
       // If necessary, compute minimum images.
-      if (!hasMinimumImages_) {
+      if (!hasMinImages_) {
          computeMinimumImages(); // computes both min images and kSq
          return;
       }
@@ -177,7 +177,7 @@ namespace Cpu {
       if (hasdKSq_) return; // dKSq already calculated
 
       // Compute minimum images if needed
-      if (!hasMinimumImages_) {
+      if (!hasMinImages_) {
          computeMinimumImages(); 
       }
 

--- a/src/prdc/cuda/WaveList.h
+++ b/src/prdc/cuda/WaveList.h
@@ -30,10 +30,19 @@ namespace Cuda {
    * In particular, minimum images, square norms of wavevectors (kSq), and
    * derivatives of the square norms of wavevectors with respect to the
    * lattice parameters (dKSq) are calculated and stored by this class.
+   * 
    * Any time the lattice parameters change the clearUnitCellData() method
    * should be called, which will effectively reset the WaveList object so
    * that the wavevector properties will need to be recalculated before
    * being used.
+   * 
+   * This object calculates these wavevector properties for a mesh of grid
+   * points in k-space. If a calculation only requires real-valued fields, 
+   * PSCF uses a reduced-size k-space mesh, as output by FFTW. However, a 
+   * full-sized k-space mesh (the same size as the real-space mesh) is 
+   * necessary when dealing with complex-valued fields. The k-space mesh
+   * used by a WaveList object is determined by the parameter isRealField,
+   * which is assigned in the constructor and cannot later be changed. 
    */
    template <int D>
    class WaveList
@@ -42,8 +51,10 @@ namespace Cuda {
 
       /**
       * Constructor.
+      * 
+      * \param isRealField  Will this WaveList be used for real-valued fields?
       */
-      WaveList();
+      WaveList(bool isRealField = true);
 
       /**
       * Destructor
@@ -160,6 +171,9 @@ namespace Cuda {
       * each gridpoint. The boolean represents whether the inverse of the
       * wave at the given gridpoint is an implicit wave. Implicit here is
       * used to mean any wave that is outside the bounds of the k-grid.
+      * 
+      * This method will throw an error if isRealField == false, because
+      * there are no implicit inverses in such a case.
       */
       DeviceArray<bool> const & implicitInverse() const;
 
@@ -186,6 +200,12 @@ namespace Cuda {
       */
       bool hasdKSq() const
       {  return hasdKSq_; }
+
+      /**
+      * Does this WaveList correspond to real-valued fields?
+      */ 
+      bool isRealField() const
+      {  return isRealField_; }
 
    private:
 
@@ -243,6 +263,9 @@ namespace Cuda {
       /// Has the dKSq array been computed?
       bool hasdKSq_;
 
+      /// Will this WaveList be used for real-valued fields?
+      bool isRealField_;
+
       /// Pointer to associated UnitCell<D> object
       UnitCell<D> const * unitCellPtr_;
 
@@ -298,6 +321,7 @@ namespace Cuda {
    inline DeviceArray<bool> const & WaveList<D>::implicitInverse() const
    {
       UTIL_CHECK(isAllocated_);
+      UTIL_CHECK(isRealField_);
       return implicitInverse_;
    }
 

--- a/src/prdc/cuda/WaveList.h
+++ b/src/prdc/cuda/WaveList.h
@@ -38,7 +38,7 @@ namespace Cuda {
    * 
    * This object calculates these wavevector properties for a mesh of grid
    * points in k-space. If a calculation only requires real-valued fields, 
-   * PSCF uses a reduced-size k-space mesh, as output by FFTW. However, a 
+   * PSCF uses a reduced-size k-space mesh, as output by cuFFT. However, a 
    * full-sized k-space mesh (the same size as the real-space mesh) is 
    * necessary when dealing with complex-valued fields. The k-space mesh
    * used by a WaveList object is determined by the parameter isRealField,
@@ -82,14 +82,13 @@ namespace Cuda {
       *
       * The minimum images may change if a lattice angle in the unit cell
       * is changed, so this method should be called whenever such changes
-      * occur. The method hasVariableAngle() identifies whether the
-      * minimum images may change under changes in the lattice parameters.
+      * occur. 
       *
       * In the process of computing the minimum images, the square norm
       * |k|^2 for all wavevectors is also calculated and stored, so it
       * is not necessary to call computeKSq after calling this method.
-      * Function computeKSq() can be used to allow calculation of kSq
-      * without unnecessary recalculation of minimum images.
+      * computeKSq is provided to allow calculation of kSq without 
+      * recalculating minimum images.
       */
       void computeMinimumImages();
 
@@ -113,7 +112,8 @@ namespace Cuda {
       * points in the FFT k-space mesh. The array is unwrapped into a
       * linear array in an index-by-index manner, in which the first kSize
       * elements of the array contain the first index of each minimum
-      * image, and so on.
+      * image, and so on. If isRealField is true, kSize is smaller than 
+      * the size of the real-space mesh. Otherwise, it is equal.
       */
       DeviceArray<int> const & minImages_d() const;
 
@@ -121,44 +121,36 @@ namespace Cuda {
       * Get minimum images as IntVec<D> objects on the host.
       *
       * The array has size kSize, and each element is an IntVec<D>.
+      * If isRealField is true, kSize is smaller than the size of the 
+      * real-space mesh. Otherwise, it is equal.
       */
       HostDArray< IntVec<D> > const & minImages_h() const;
 
       /**
       * Get the kSq array on the device by reference.
+      * 
+      * This method returns an RField in which each element is the square
+      * magnitude |k|^2 of a wavevector k in the k-space mesh used for the 
+      * DFT. If isRealField is true, this k-space mesh is smaller than the 
+      * real-space mesh. Otherwise, it is the same size.
       */
       RField<D> const & kSq() const;
 
-      #if 0
       /**
-      * Get the full dKSq array on the device by reference.
+      * Get derivatives of |k|^2 with respect to lattice parameter i.
       *
-      * The array has size kSize * nParams, where kSize is the number of
-      * grid points in reciprocal space and nParams is the number of
-      * lattice parameters. The array is unwrapped into a linear array in
-      * which the * first kSize elements of the array contain dKSq for the
-      * first lattice parameter, and so on.
-      *
-      * Each element of the array that is returned is the product of a 
-      * prefactor and the derivative of |k|^2 with respect to a lattice
-      * parameter. The prefactor is 2.0 if the vector has an implicit
-      * inverse and 1.0 otherwise. The prefactors are chosen to simplify
-      * use of this array to compute stress contributions in the Block
-      * class.
-      */
-      DeviceArray<cudaReal> const & dKSq() const;
-      #endif
-
-      /**
-      * Get derivatives of |k|^2 with respect to a lattice parameter.
-      *
-      * Return value is a constant reference to an array of size kSize 
-      * in which each element is the derivative of the square wavevector 
-      * with respect lattice parameter i, multiplied by a prefactor. The 
-      * prefactor is 2.0 if the associated wavevector has an implicit 
-      * inverse, and 1.0 otherwise. These prefactors are chosen to simplify
-      * use of this array to compute stress contributions in the Block
-      * class. 
+      * This method returns an RField in which each element is the 
+      * derivative of the square-wavevector with respect to unit cell 
+      * parameter i, multiplied by a prefactor. The prefactor is 2.0 for 
+      * waves that have an implicit inverse and 1.0 otherwise. The choice 
+      * of prefactor is designed to simplify use of the array to compute 
+      * stress.
+      * 
+      * Each element corresponds to one wavevector k in the k-space mesh 
+      * used for the DFT. If isRealField is true, this k-space mesh is 
+      * smaller than the real-space mesh. Otherwise, it is the same size.
+      * In the latter case, there are no implicit waves, so the prefactor
+      * is always 1.0.
       *
       * \param i index of lattice parameter
       */
@@ -215,7 +207,9 @@ namespace Cuda {
       * The array has size kSize * D, where kSize is the number of grid 
       * points in reciprocal space. The array is unwrapped into a linear 
       * array in which the first kSize elements of the array contain the
-      * the first coordinate for all minimum image, and so on.
+      * the first coordinate for all minimum image, and so on. If 
+      * isRealField is true, kSize is smaller than the size of the 
+      * real-space mesh. Otherwise, it is equal.
       */
       DeviceArray<int> minImages_;
 
@@ -224,7 +218,9 @@ namespace Cuda {
       *
       * Each element of minImageVecs_ contains all D coordinates of the
       * minimum image for a single wavevector, stored on the host as an 
-      * IntVec<D>. The array has capacity kSize_.
+      * IntVec<D>. The array has capacity kSize_. If isRealField is true, 
+      * kSize_ is smaller than the size of the real-space mesh. Otherwise, 
+      * it is equal.
       */
       mutable
       HostDArray< IntVec<D> > minImages_h_;
@@ -241,10 +237,22 @@ namespace Cuda {
       /// Array indicating whether a given gridpoint has an implicit partner
       DeviceArray<bool> implicitInverse_;
 
-      /// Dimensions of the mesh in reciprocal space.
+      /**
+      * Dimensions of the mesh in reciprocal space.
+      * 
+      * If isRealField_, the reciprocal-space grid is smaller than the 
+      * real-space grid, as output by cuFFT. Otherwise, the two grids
+      * are the same size.
+      */ 
       IntVec<D> kMeshDimensions_;
 
-      /// Number of grid points in reciprocal space.
+      /**
+      * Number of grid points in reciprocal space.
+      * 
+      * If isRealField_, the reciprocal-space grid is smaller than the 
+      * real-space grid, as output by cuFFT. Otherwise, the two grids
+      * are the same size.
+      */ 
       int kSize_;
 
       /// Has memory been allocated for arrays?
@@ -297,16 +305,6 @@ namespace Cuda {
       UTIL_CHECK(hasKSq_);
       return kSq_;
    }
-
-   #if 0
-   // Get the full dKSq array on the device by reference.
-   template <int D>
-   inline DeviceArray<cudaReal> const & WaveList<D>::dKSq() const
-   {
-      UTIL_CHECK(hasdKSq_);
-      return dKSq_;
-   }
-   #endif
 
    // Get a slice of the dKSq array on the device by reference.
    template <int D>

--- a/src/prdc/cuda/WaveList.tpp
+++ b/src/prdc/cuda/WaveList.tpp
@@ -11,6 +11,7 @@
 #include "WaveList.h"
 
 #include <prdc/cuda/resources.h>
+#include <prdc/cuda/FFT.h>
 #include <prdc/crystal/hasVariableAngle.h>
 #include <pscf/cuda/HostDArray.h>
 #include <pscf/mesh/MeshIterator.h>
@@ -451,6 +452,7 @@ namespace Cuda {
       meshPtr_ = &m;
 
       int nParams = unitCell().nParameter();
+      IntVec<D> const & meshDimensions = mesh().dimensions();
 
       // Compute kMeshDimensions_ and kSize_
       if (isRealField_) {

--- a/src/prdc/tests/cpu/CpuWaveListTest.h
+++ b/src/prdc/tests/cpu/CpuWaveListTest.h
@@ -97,17 +97,17 @@ public:
       Cpu::WaveList<1> wavelist1;
       wavelist1.allocate(mesh1, cell1);
       TEST_ASSERT(wavelist1.isAllocated());
-      TEST_ASSERT(!wavelist1.hasMinimumImages());
+      TEST_ASSERT(!wavelist1.hasMinImages());
 
       Cpu::WaveList<2> wavelist2;
       wavelist2.allocate(mesh2, cell2);
       TEST_ASSERT(wavelist2.isAllocated());
-      TEST_ASSERT(!wavelist2.hasMinimumImages());
+      TEST_ASSERT(!wavelist2.hasMinImages());
 
       Cpu::WaveList<3> wavelist3;
       wavelist3.allocate(mesh3, cell3);
       TEST_ASSERT(wavelist3.isAllocated());
-      TEST_ASSERT(!wavelist3.hasMinimumImages());
+      TEST_ASSERT(!wavelist3.hasMinImages());
    }
 
    void testComputeMinimumImages1D()

--- a/src/prdc/tests/cpu/CpuWaveListTest.h
+++ b/src/prdc/tests/cpu/CpuWaveListTest.h
@@ -123,13 +123,13 @@ public:
       Cpu::WaveList<1> wavelist;
       wavelist.allocate(mesh1, cell1);
 
-      // Compute minimum images (and ksq) on device, transfer to host
+      // Compute minimum images (and ksq)
       wavelist.computeMinimumImages(); 
-      DArray< IntVec<1> > const & minImages_h = wavelist.minImages();
-      Cpu::RField<1> const & ksq_h = wavelist.kSq();
+      DArray< IntVec<1> > const & minImages = wavelist.minImages();
+      Cpu::RField<1> const & ksq = wavelist.kSq();
       DArray<bool> const & implicit = wavelist.implicitInverse();
 
-      // Compute minimum images (and ksq) on host and compare
+      // Compute minimum images (and ksq) locally and compare
       IntVec<1> temp, vec;
       MeshIterator<1> iter;
       double val;
@@ -143,8 +143,8 @@ public:
          flag = implicit[rank];
          val = cell1.ksq(vec);
          
-         TEST_ASSERT(vec == minImages_h[rank]);
-         TEST_ASSERT(abs(val - ksq_h[rank]) < tolerance_);
+         TEST_ASSERT(vec == minImages[rank]);
+         TEST_ASSERT(abs(val - ksq[rank]) < tolerance_);
          TEST_ASSERT(flag == Cpu::FFT<1>::hasImplicitInverse(temp, meshDims1));
       }
 
@@ -164,25 +164,25 @@ public:
       Cpu::WaveList<2> wavelist;
       wavelist.allocate(mesh2, cell2);
 
-      // compute minimum images (and ksq) on device, transfer to host
+      // compute minimum images (and ksq)
       wavelist.computeMinimumImages(); 
-      DArray< IntVec<2> > const & minImages_h = wavelist.minImages();
-      Cpu::RField<2> ksq_h = wavelist.kSq();
-      TEST_ASSERT(minImages_h.capacity() == kSize2);
-      TEST_ASSERT(ksq_h.capacity() == kSize2);
+      DArray< IntVec<2> > const & minImages = wavelist.minImages();
+      Cpu::RField<2> ksq = wavelist.kSq();
+      TEST_ASSERT(minImages.capacity() == kSize2);
+      TEST_ASSERT(ksq.capacity() == kSize2);
 
-      // compute minimum images (and ksq) on host and compare
+      // compute minimum images (and ksq) locally and compare
       IntVec<2> temp, vec;
       MeshIterator<2> iter;
-      double ksq;
+      double val;
       iter.setDimensions(kMeshDims2);
       for (iter.begin(); !iter.atEnd(); ++iter) {
          temp = iter.position();
          vec = shiftToMinimum(temp, mesh2.dimensions(), cell2);
-         ksq = cell2.ksq(vec);
+         val = cell2.ksq(vec);
          
-         TEST_ASSERT(vec == minImages_h[iter.rank()]);
-         TEST_ASSERT(abs(ksq - ksq_h[iter.rank()]) < tolerance_);
+         TEST_ASSERT(vec == minImages[iter.rank()]);
+         TEST_ASSERT(abs(val - ksq[iter.rank()]) < tolerance_);
       }
    }
 
@@ -202,23 +202,23 @@ public:
       Cpu::WaveList<3> wavelist;
       wavelist.allocate(mesh3, cell3);
 
-      // Compute minimum images (and ksq) on device, transfer to host
+      // Compute minimum images (and ksq)
       wavelist.computeMinimumImages(); 
-      DArray< IntVec<3> > const & minImages_h = wavelist.minImages();
-      Cpu::RField<3> const & ksq_h = wavelist.kSq();
+      DArray< IntVec<3> > const & minImages = wavelist.minImages();
+      Cpu::RField<3> const & ksq = wavelist.kSq();
 
-      // Compute minimum images (and ksq) on host and compare
+      // Compute minimum images (and ksq) locally and compare
       IntVec<3> temp, vec;
       MeshIterator<3> iter;
-      double ksq;
+      double val;
       iter.setDimensions(kMeshDims3);
       for (iter.begin(); !iter.atEnd(); ++iter) {
          temp = iter.position();
          vec = shiftToMinimum(temp, mesh3.dimensions(), cell3);
-         ksq = cell3.ksq(vec);
+         val = cell3.ksq(vec);
 
-         TEST_ASSERT(vec == minImages_h[iter.rank()]);
-         TEST_ASSERT(abs(ksq - ksq_h[iter.rank()]) < tolerance_);
+         TEST_ASSERT(vec == minImages[iter.rank()]);
+         TEST_ASSERT(abs(val - ksq[iter.rank()]) < tolerance_);
       }
    }
 
@@ -236,23 +236,23 @@ public:
 
       // Compute kSq two different ways
       wavelist.computeMinimumImages(); // calculates kSq
-      Cpu::RField<1> const & ksq_h = wavelist.kSq();
+      Cpu::RField<1> const & ksq = wavelist.kSq();
       wavelist.clearUnitCellData(); // resets kSq but not min images
       wavelist.computeKSq(); // recalculates kSq 
-      Cpu::RField<1> const & ksq_h2 = wavelist.kSq();
+      Cpu::RField<1> const & ksq2 = wavelist.kSq();
 
-      // Compute kSq on host and compare
+      // Compute kSq locally and compare
       IntVec<1> temp, vec;
-      double ksq;
+      double val;
       MeshIterator<1> iter;
       iter.setDimensions(kMeshDims1);
       for (iter.begin(); !iter.atEnd(); ++iter) {
          temp = iter.position();
          vec = shiftToMinimum(temp, mesh1.dimensions(), cell1);
-         ksq = cell1.ksq(vec);
+         val = cell1.ksq(vec);
 
-         TEST_ASSERT(abs(ksq - ksq_h[iter.rank()]) < tolerance_);
-         TEST_ASSERT(abs(ksq - ksq_h2[iter.rank()]) < tolerance_);
+         TEST_ASSERT(abs(val - ksq[iter.rank()]) < tolerance_);
+         TEST_ASSERT(abs(val - ksq2[iter.rank()]) < tolerance_);
       }
    }
 
@@ -280,10 +280,10 @@ public:
 
       // Compute kSq two different ways
       wavelist.computeMinimumImages(); // calculates kSq
-      Cpu::RField<2> const & ksq_h = wavelist.kSq();
+      Cpu::RField<2> const & ksq = wavelist.kSq();
       wavelist.clearUnitCellData(); // resets kSq but not min images
       wavelist.computeKSq(); // recalculates kSq using a different kernel
-      Cpu::RField<2> const & ksq_h2 = wavelist.kSq();
+      Cpu::RField<2> const & ksq2 = wavelist.kSq();
 
       // Compute kSq in wavelist and test
       IntVec<2> pos, vec;
@@ -295,8 +295,8 @@ public:
          vec = shiftToMinimum(pos, mesh2.dimensions(), cell);
          val = cell.ksq(vec);
 
-         TEST_ASSERT(abs(val - ksq_h[iter.rank()]) < tolerance_);
-         TEST_ASSERT(abs(val - ksq_h2[iter.rank()]) < tolerance_);
+         TEST_ASSERT(abs(val - ksq[iter.rank()]) < tolerance_);
+         TEST_ASSERT(abs(val - ksq2[iter.rank()]) < tolerance_);
       }
    }
 
@@ -316,14 +316,14 @@ public:
       Cpu::WaveList<3> wavelist;
       wavelist.allocate(mesh3, cell);
 
-      // Compute kSq on device two different ways, transfer to host
+      // Compute kSq two different ways
       wavelist.computeMinimumImages(); // calculates kSq
-      Cpu::RField<3> const & ksq_h = wavelist.kSq();
+      Cpu::RField<3> const & ksq = wavelist.kSq();
       wavelist.clearUnitCellData(); // resets kSq but not min images
       wavelist.computeKSq(); // recalculates kSq using a different kernel
-      Cpu::RField<3> const & ksq_h2 = wavelist.kSq();
+      Cpu::RField<3> const & ksq2 = wavelist.kSq();
 
-      // Compute kSq on host and compare
+      // Compute kSq locally and compare
       IntVec<3> temp, vec;
       double val;
       MeshIterator<3> iter;
@@ -333,8 +333,8 @@ public:
          vec = shiftToMinimum(temp, mesh3.dimensions(), cell);
          val = cell.ksq(vec);
 
-         TEST_ASSERT(abs(val - ksq_h[iter.rank()]) < tolerance_);
-         TEST_ASSERT(abs(val - ksq_h2[iter.rank()]) < tolerance_);
+         TEST_ASSERT(abs(val - ksq[iter.rank()]) < tolerance_);
+         TEST_ASSERT(abs(val - ksq2[iter.rank()]) < tolerance_);
       }
    }
 
@@ -346,11 +346,11 @@ public:
       Cpu::WaveList<1> wavelist;
       wavelist.allocate(mesh1, cell1);
 
-      // Compute dKSq on device, transfer to host
+      // Compute dKSq
       wavelist.computedKSq();
-      Cpu::RField<1> dksq_h = wavelist.dKSq(0);
+      Cpu::RField<1> dksq = wavelist.dKSq(0);
 
-      // Compute dKSq on host and compare
+      // Compute dKSq locally and compare
       IntVec<1> pos, vec;
       double val;
       MeshIterator<1> iter;
@@ -364,7 +364,7 @@ public:
                val *= 2.0;
             }
          }
-         TEST_ASSERT(abs(val - dksq_h[iter.rank()]) < tolerance_);
+         TEST_ASSERT(abs(val - dksq[iter.rank()]) < tolerance_);
       }
    }
 
@@ -376,13 +376,13 @@ public:
       wavelist.allocate(mesh2, cell2);
       wavelist.computedKSq();
 
-      // compute dKSq on host and compare
+      // compute dKSq locally and compare
       IntVec<2> pos, vec;
       double val;
       MeshIterator<2> iter;
       iter.setDimensions(kMeshDims2);
       for (int n = 0; n < cell2.nParameter() ; ++n) {
-         Cpu::RField<2> const & dksq_h = wavelist.dKSq(n);
+         Cpu::RField<2> const & dksq = wavelist.dKSq(n);
          for (iter.begin(); !iter.atEnd(); ++iter) {
             pos = iter.position();
             vec = shiftToMinimum(pos, mesh2.dimensions(), cell2);
@@ -392,7 +392,7 @@ public:
                   val *= 2.0;
                }
             }
-            TEST_ASSERT(abs(val - dksq_h[iter.rank()]) < tolerance_);
+            TEST_ASSERT(abs(val - dksq[iter.rank()]) < tolerance_);
          }
       }
    }
@@ -405,12 +405,13 @@ public:
       wavelist.allocate(mesh3, cell3);
       wavelist.computedKSq();
 
+      // compute dKSq locally and compare
       IntVec<3> pos, vec;
       double val;
       MeshIterator<3> iter;
       iter.setDimensions(kMeshDims3);
       for (int n = 0; n < cell3.nParameter() ; ++n) {
-         Cpu::RField<3> const & dksq_h = wavelist.dKSq(n);
+         Cpu::RField<3> const & dksq = wavelist.dKSq(n);
          for (iter.begin(); !iter.atEnd(); ++iter) {
             pos = iter.position();
             vec = shiftToMinimum(pos, mesh3.dimensions(), cell3);
@@ -420,7 +421,47 @@ public:
                   val *= 2.0;
                }
             }
-            TEST_ASSERT(abs(val - dksq_h[iter.rank()]) < tolerance_);
+            TEST_ASSERT(abs(val - dksq[iter.rank()]) < tolerance_);
+         }
+      }
+   }
+
+   void testComplex()
+   {
+      printMethod(TEST_FUNC);
+
+      Cpu::WaveList<3> wavelist(false);
+      wavelist.allocate(mesh3, cell3);
+      wavelist.computedKSq(); // computes min images, ksq, and dksq
+
+      DArray< IntVec<3> > const & minImages = wavelist.minImages();
+      Cpu::RField<3> const & ksq = wavelist.kSq();
+      DArray< Cpu::RField<3> > const & dksq = wavelist.dKSq();
+
+      // Check that array sizes are correct
+      TEST_ASSERT(minImages.capacity() == mesh3.size());
+      TEST_ASSERT(ksq.capacity() == mesh3.size());
+      TEST_ASSERT(dksq.capacity() == cell3.nParameter());
+      for (int i = 0; i < cell3.nParameter(); i++) {
+         TEST_ASSERT(dksq[i].capacity() == mesh3.size());
+      }
+
+      // Compute minimum images, ksq, and dksq locally and compare
+      IntVec<3> temp, vec;
+      MeshIterator<3> iter;
+      double val;
+      iter.setDimensions(mesh3.dimensions());
+      for (iter.begin(); !iter.atEnd(); ++iter) {
+         temp = iter.position();
+         vec = shiftToMinimum(temp, mesh3.dimensions(), cell3);
+         val = cell3.ksq(vec);
+
+         TEST_ASSERT(vec == minImages[iter.rank()]);
+         TEST_ASSERT(abs(val - ksq[iter.rank()]) < tolerance_);
+
+         for (int i = 0; i < cell3.nParameter(); i++) {
+            val = cell3.dksq(vec, i);
+            TEST_ASSERT(abs(val - dksq[i][iter.rank()]) < tolerance_);
          }
       }
    }
@@ -438,6 +479,7 @@ TEST_ADD(CpuWaveListTest, testComputeKSq3D)
 TEST_ADD(CpuWaveListTest, testComputedKSq1D)
 TEST_ADD(CpuWaveListTest, testComputedKSq2D)
 TEST_ADD(CpuWaveListTest, testComputedKSq3D)
+TEST_ADD(CpuWaveListTest, testComplex)
 TEST_END(CpuWaveListTest)
 
 #endif

--- a/src/prdc/tests/cpu/CpuWaveListTest.h
+++ b/src/prdc/tests/cpu/CpuWaveListTest.h
@@ -53,7 +53,6 @@ public:
       // IntVec<1> meshDims1; 
       meshDims1[0] = 32; 
       mesh1.setDimensions(meshDims1);
-      IntVec<1> kMeshDims1;
       kMeshDims1[0] = (meshDims1[0] / 2) + 1;
       kSize1 = kMeshDims1[0];
 
@@ -116,8 +115,8 @@ public:
       printMethod(TEST_FUNC);
 
       TEST_ASSERT(mesh1.dimension(0) == 32);
-      TEST_ASSERT(kMeshDims1[0] = 17);
-      TEST_ASSERT(kSize1 = 17);
+      TEST_ASSERT(kMeshDims1[0] == 17);
+      TEST_ASSERT(kSize1 == 17);
 
       // set up wavelist object
       Cpu::WaveList<1> wavelist;
@@ -227,8 +226,8 @@ public:
       printMethod(TEST_FUNC);
 
       TEST_ASSERT(mesh1.dimension(0) == 32);
-      TEST_ASSERT(kMeshDims1[0] = 17);
-      TEST_ASSERT(kSize1 = 17);
+      TEST_ASSERT(kMeshDims1[0] == 17);
+      TEST_ASSERT(kSize1 == 17);
 
       // set up wavelist object
       Cpu::WaveList<1> wavelist;


### PR DESCRIPTION
This pull request adds a new boolean variable `hasRealFields_` to the `WaveList` classes in `Prdc`. This variable determines whether the `WaveList` data are calculated on the reduced-size FFT k-grid (for Fourier transforms of real fields) or the full-sized k-grid (for transforms of complex fields). 

Documentation of methods has been updated as well, to reflect the fact that the arrays output by accessor methods of the `WaveList` class are variable in size, depending on `hasRealFields_`. Other documentation updates and variable name changes were made for consistency between the CPU and CUDA `WaveList` classes. 

One unit test was also added for each `WaveList` class, ensuring that the array sizes and values are correct when `hasRealFields_ == false`. All unit tests pass on both CPU and GPU.